### PR TITLE
fix parse error if template removes the newline

### DIFF
--- a/lib/templates.rake
+++ b/lib/templates.rake
@@ -10,7 +10,7 @@ end
 
 def metadata(text)
   # Pull out the first erb comment only - /m is for a multiline regex
-  extracted = text.match(/<%\#(.+?)%>/m)
+  extracted = text.match(/<%\#(.+?).-?%>/m)
   extracted == nil ? {} : YAML.load(extracted[1])
 end
 


### PR DESCRIPTION
As discussed on IRC a template causes a parse error if it removes the newline:
http://pastebin.com/TPpcs0Fm
