### PR TITLE
join prefix and template name with empty string only

### DIFF
--- a/lib/templates.rake
+++ b/lib/templates.rake
@@ -142,7 +142,7 @@ namespace :templates do
         filename = template.split('/').last
         title    = filename.split('.').first
         @name    = @metadata ['name'] || title
-        @name    = [prefix, @name].compact.join(' ')
+        @name    = [prefix, @name].compact.join()
         next if filter and not @name.match(/#{filter}/i)
 
         unless @metadata['kind']


### PR DESCRIPTION
As a Foreman admin I'm moving the template management from the UI to Git using the templates:sync task. Since all my templates don't contain any whitespace in the name it would be great to keep that when using templates:sync.

This is not possible at moment because when joining prefix and template name a whitespace will be added automatically.

People that wish a whitespace after the prefix can solve this by appending it to the prefix itself. :)