### PR TITLE
Update link to foreman plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ of your choice) to your local Foreman instance
 
 ## Installation
 
-See [How_to_Install_a_Plugin](http://projects.theforeman.org/projects/foreman/wiki/How_to_Install_a_Plugin)
-for how to install Foreman plugins
+See [Install a plugin](http://theforeman.org/manuals/latest/index.html#6.1InstallaPlugin) in the 
+Foreman documentation for how to install Foreman plugins.
 
 The gem name is "foreman_templates".
 


### PR DESCRIPTION
I think this is a better link to the plugin installation documentation, as the old link points to what seems to be an outdated page that links forward to the proposed link.