### PR TITLE
make templates.rake Rails 4 compatible

### DIFF
--- a/lib/templates.rake
+++ b/lib/templates.rake
@@ -32,7 +32,7 @@ def update_template
     raise NoKindError
   end
 
-  db_template = ProvisioningTemplate.find_or_initialize_by_name(@name)
+  db_template = ProvisioningTemplate.where(name: @name).first_or_initialize
   data = {
     :template         => @text,
     :snippet          => false,
@@ -64,7 +64,7 @@ def update_template
 end
 
 def update_ptable
-  db_ptable = Ptable.find_or_initialize_by_name(@name)
+  db_ptable = Ptable.where(name: @name).first_or_initialize
   data = { :layout => @text }
   string = db_ptable.new_record? ? "Created" : "Updated"
 
@@ -91,7 +91,7 @@ def update_ptable
 end
 
 def update_snippet
-  db_snippet = ProvisioningTemplate.find_or_initialize_by_name(@name)
+  db_snippet = ProvisioningTemplate.where(name: @name).first_or_initialize
   data = {
     :template => @text,
     :snippet => true

--- a/test/lib/tasks/templates_test.rb
+++ b/test/lib/tasks/templates_test.rb
@@ -71,19 +71,19 @@ class PluginTemplateTest < ActiveSupport::TestCase
 
     # Check template was imported
     ct = ProvisioningTemplate.find_by_name('FooBar Test Data')
-    assert_present ct
+    assert ct.present?
     assert_equal File.read(get_template('metadata1.erb')), ct.template
     assert_equal 1, ct.operatingsystems.size
     assert_equal Operatingsystem.find_by_title('Ubuntu 10.10').id, ct.operatingsystems.first.id
 
     # Check snippet was imported
     sp = ProvisioningTemplate.find_by_name('FooBar Test Snippet')
-    assert_present sp
+    assert sp.present?
     assert_equal File.read(get_template('snippet1.erb')), sp.template
 
     # Check ptable was imported
     pt = Ptable.find_by_name('FooBar Test Ptable')
-    assert_present pt
+    assert pt.present?
     assert_equal File.read(get_template('ptable1.erb')), pt.layout
     assert_equal "Debian", pt.os_family
   end


### PR DESCRIPTION
Still works for me with Foreman 1.10. We need a 2.0.3 release then.