### PR TITLE
Support metadata snippet flag.

### DIFF
--- a/lib/templates.rake
+++ b/lib/templates.rake
@@ -50,7 +50,7 @@ def update_template
   db_template = ProvisioningTemplate.where(:name => @name).first_or_initialize
   data = {
     :template         => @text,
-    :snippet          => false,
+    :snippet          => @snippet,
     :template_kind_id => kind.id
   }
   string = db_template.new_record? ? "Created" : "Updated"
@@ -80,7 +80,10 @@ end
 
 def update_ptable
   db_ptable = Ptable.where(:name => @name).first_or_initialize
-  data = { :layout => @text }
+  data = {
+    :layout  => @text,
+    :snippet => @snippet
+  }
   string = db_ptable.new_record? ? "Created" : "Updated"
 
   oses = map_oses
@@ -177,6 +180,8 @@ namespace :templates do
         @name    = @metadata['name'] || title
         @name    = [prefix, @name].compact.join()
         next if filter and not @name.match(/#{filter}/i)
+
+        @snippet = @metadata['snippet'] || false
 
         unless @metadata['kind']
           puts "  Error: Must specify template kind"

--- a/test/lib/tasks/templates_test.rb
+++ b/test/lib/tasks/templates_test.rb
@@ -94,10 +94,11 @@ class PluginTemplateTest < ActiveSupport::TestCase
     test 'when associate is never, os should be unaffected on create' do
       # Set up the data wanted by update_template
       @os        = FactoryGirl.create(:operatingsystem)
-      @metadata  = { 'kind' => 'provision', 'oses' => [@os.to_label] }
+      @metadata  = { 'kind' => 'provision', 'snippet' => false, 'oses' => [@os.to_label] }
       @name      = "New Name"
       @text      = "New template data"
       @associate = 'never'
+      @snippet   = false
 
       update_template # creates new template
 
@@ -112,10 +113,11 @@ class PluginTemplateTest < ActiveSupport::TestCase
       @pt = FactoryGirl.create(:provisioning_template, :template_kind => @tk, :operatingsystems => [])
 
       # Set up the data wanted by update_template
-      @metadata  = { 'kind' => @tk.name, 'oses' => [@os.to_label] }
+      @metadata  = { 'kind' => @tk.name, 'snippet' => false, 'oses' => [@os.to_label] }
       @name      = @pt.name
       @text      = "New template data"
       @associate = 'always'
+      @snippet   = false
 
       update_template # creates new template
 


### PR DESCRIPTION
This adds support of importing snippets as either provisioning or ptable as discussed in theforeman/foreman_templates#24.  It does so by adding a boolean to the metadata named snippet and defaults to false so backwards compatibility is maintained.