### PR TITLE
Ignore vim modeline on the first line

### DIFF
--- a/lib/templates.rake
+++ b/lib/templates.rake
@@ -11,7 +11,7 @@ end
 
 def metadata(text)
   # Pull out the first erb comment only - /m is for a multiline regex
-  extracted = text.match(/<%\#(.+?).-?%>/m)
+  extracted = text.match(/<%\#[\t a-z0-9=:]*(.+?).-?%>/m)
   extracted == nil ? {} : YAML.load(extracted[1])
 end
 


### PR DESCRIPTION
SSIA

```
$ ruby -e "puts STDIN.read.match(/<%\#\s?vim:\s?[a-z0-9=:]*(.+?).-?%>/m)[1]"
<%# vim:sw=2:ts=2:et
kind: snippet
name: kickstart_cmdline
-%>

kind: snippet
name: kickstart_cmdline
```