### PR TITLE
Support Organizations & Locations metadata

### DIFF
--- a/app/models/concerns/foreman_templates/provisioning_template_import.rb
+++ b/app/models/concerns/foreman_templates/provisioning_template_import.rb
@@ -17,7 +17,9 @@ module ForemanTemplates::ProvisioningTemplateImport
         :snippet          => false,
         :template_kind_id => kind.id
       }
-      oses = map_oses(metadata)
+      oses = map_metadata(metadata, 'oses')
+      locations = map_metadata(metadata, 'locations')
+      organizations = map_metadata(metadata, 'organizations')
 
       # Printout helpers
       c_or_u = template.new_record? ? 'Created' : 'Updated'
@@ -25,6 +27,8 @@ module ForemanTemplates::ProvisioningTemplateImport
 
       if (metadata['associate'] == 'new' && template.new_record?) || (metadata['associate'] == 'always')
         data[:operatingsystem_ids] = oses.map(&:id)
+        data[:location_ids] = locations.map(&:id)
+        data[:organization_ids] = organizations.map(&:id)
       end
 
       if data[:template] != template.template
@@ -36,27 +40,21 @@ module ForemanTemplates::ProvisioningTemplateImport
         status  = template.update_attributes(data)
         result  = "  #{c_or_u} Template #{id_string}:#{name}"
         result += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
-      elsif data[:operatingsystem_ids]
+        result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
+        result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
+      elsif data[:operatingsystem_ids] || data[:location_ids] || data[:organization_ids]
         diff    = nil
         status  = template.update_attributes(data)
         result  = "  #{c_or_u} Template Associations #{id_string}:#{name}"
         result += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
+        result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
+        result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
       else
         diff    = nil
         status  = true
         result  = "  No change to Template #{id_string}:#{name}"
       end
       { :diff => diff, :status => status, :result => result }
-    end
-
-    def map_oses(metadata)
-      if metadata['oses']
-        metadata['oses'].map do |os|
-          Operatingsystem.all.map { |db| db.to_label =~ /^#{os}/ ? db : nil }
-        end.flatten.compact
-      else
-        []
-      end
     end
   end
 end

--- a/app/models/concerns/foreman_templates/ptable_import.rb
+++ b/app/models/concerns/foreman_templates/ptable_import.rb
@@ -9,7 +9,9 @@ module ForemanTemplates::PtableImport
       # Data
       ptable = Ptable.where(:name => name).first_or_initialize
       data = { :layout => text }
-      oses = map_oses(metadata)
+      oses = map_metadata(metadata, 'oses')
+      locations = map_metadata(metadata, 'locations')
+      organizations = map_metadata(metadata, 'organizations')
 
       # Printout helpers
       c_or_u = ptable.new_record? ? 'Created' : 'Updated'
@@ -17,6 +19,8 @@ module ForemanTemplates::PtableImport
 
       if (metadata['associate'] == 'new' && ptable.new_record?) || (metadata['associate'] == 'always')
         data[:os_family] = oses.map(&:family).uniq.first
+        data[:location_ids] = locations.map(&:id)
+        data[:organization_ids] = organizations.map(&:id)
       end
 
       if data[:layout] != ptable.layout
@@ -27,28 +31,22 @@ module ForemanTemplates::PtableImport
         ).to_s(:color)
         status  = ptable.update_attributes(data)
         result  = "  #{c_or_u} Ptable #{id_string}:#{name}"
-      elsif data[:os_family]
+        result += "\n    Operatingsystem Family:\n    - #{oses.map(&:family).uniq.first}" unless oses.empty?
+        result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
+        result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
+      elsif data[:os_family] || data[:location_ids] || data[:organization_ids]
         diff    = nil
         status  = ptable.update_attributes(data)
         result  = "  #{c_or_u} Ptable Associations #{id_string}:#{name}"
         result += "\n    Operatingsystem Family:\n    - #{oses.map(&:family).uniq.first}" unless oses.empty?
+        result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
+        result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
       else
         diff    = nil
         status  = true
         result  = "  No change to Ptable #{id_string}:#{name}"
       end
       { :diff => diff, :status => status, :result => result }
-    end
-
-    # TODO: DRY this, it's copied from ProvisioningTemplateImport
-    def map_oses(metadata)
-      if metadata['oses']
-        metadata['oses'].map do |os|
-          Operatingsystem.all.map { |db| db.to_label =~ /^#{os}/ ? db : nil }
-        end.flatten.compact
-      else
-        []
-      end
     end
   end
 end

--- a/app/models/concerns/foreman_templates/template_import.rb
+++ b/app/models/concerns/foreman_templates/template_import.rb
@@ -29,5 +29,26 @@ module ForemanTemplates::TemplateImport
       end
       { :diff => diff, :status => status, :result => result }
     end
+
+    def map_metadata(metadata, param)
+      if metadata[param]
+        case param
+        when 'oses'
+          metadata[param].map do |os|
+            Operatingsystem.all.map { |db| db.to_label =~ /^#{os}/ ? db : nil }
+          end.flatten.compact
+        when 'locations'
+          metadata[param].map do |loc|
+            Location.all.map { |db| db.name =~ /^#{loc}/ ? db : nil }
+          end.flatten.compact
+        when 'organizations'
+          metadata[param].map do |org|
+            Organization.all.map { |db| db.name =~ /^#{org}/ ? db : nil }
+          end.flatten.compact
+        end
+      else
+        []
+      end
+    end
   end
 end

--- a/lib/tasks/foreman_templates_tasks.rake
+++ b/lib/tasks/foreman_templates_tasks.rake
@@ -9,7 +9,7 @@ namespace :templates do
     #* prefix    => The string all imported templates should begin with [Community ]
     #* dirname   => The directory within the git tree containing the templates [/]
     #* filter    => Import names matching this regex (case-insensitive; snippets are not filtered)
-    #* associate => Associate to OS, always, new or never  [new]
+    #* associate => Associate to OS's, Locations & Organizations. Options are: always, new or never  [new]
 
     results = ForemanTemplates::TemplateImporter.new({
       verbose:   ENV['verbose'],

--- a/test/unit/provisioning_template_test.rb
+++ b/test/unit/provisioning_template_test.rb
@@ -4,10 +4,12 @@ module ForemanTemplates
   class ProvisioningTemplateTest < ActiveSupport::TestCase
     setup do
       # create a basic template with no OS assigned
-      @tk     = FactoryGirl.create(:template_kind)
-      @os_old = FactoryGirl.create(:operatingsystem)
-      @os_new = FactoryGirl.create(:operatingsystem)
-      @pt     = FactoryGirl.create(:provisioning_template,
+      @tk      = FactoryGirl.create(:template_kind)
+      @os_old  = FactoryGirl.create(:operatingsystem)
+      @os_new  = FactoryGirl.create(:operatingsystem)
+      @new_org = FactoryGirl.create(:organization, :name => 'NewOrg')
+      @new_loc = FactoryGirl.create(:location, :name => 'NewLoc')
+      @pt      = FactoryGirl.create(:provisioning_template,
                                    :template_kind => @tk,
                                    :operatingsystems => [@os_old])
 
@@ -15,9 +17,11 @@ module ForemanTemplates
       @name     = @pt.name
       @text     = @pt.template
       @metadata = {
-        'kind'      => @tk.name,
-        'oses'      => [@os_new.to_label],
-        'associate' => 'new'
+        'kind'          => @tk.name,
+        'oses'          => [@os_new.to_label],
+        'associate'     => 'new',
+        'organizations' => [@new_org.name], 
+        'locations'     => [@new_loc.name] 
       }
     end
 
@@ -83,19 +87,23 @@ module ForemanTemplates
     end
 
     context 'when associate=new' do
-      test 'os should be set for a new template' do
+      test 'os/org/loc should be set for a new template' do
         name = 'New Associate'
         ProvisioningTemplate.import!(name, @text, @metadata)
 
         ct = ProvisioningTemplate.find_by_name(name)
         assert_equal [@os_new], ct.operatingsystems
+        assert (ct.organization_ids.include? @new_org.id)
+        assert (ct.location_ids.include? @new_loc.id)
       end
 
-      test 'os should be unchanged for an existing template' do
+      test 'os/org/loc should be unchanged for an existing template' do
         ProvisioningTemplate.import!(@name, @text, @metadata)
 
         ct = ProvisioningTemplate.find_by_name(@name)
         assert_equal [@os_old], ct.operatingsystems
+        assert (not ct.organization_ids.include? @new_org.id)
+        assert (not ct.location_ids.include? @new_loc.id)
       end
     end
 
@@ -104,19 +112,23 @@ module ForemanTemplates
         @metadata['associate'] = 'always'
       end
 
-      test 'os should be set for a new template' do
+      test 'os/org/loc should be set for a new template' do
         name = 'Always Associate'
         ProvisioningTemplate.import!(name, @text, @metadata)
 
         ct = ProvisioningTemplate.find_by_name(name)
         assert_equal [@os_new], ct.operatingsystems
+        assert (ct.organization_ids.include? @new_org.id)
+        assert (ct.location_ids.include? @new_loc.id)
       end
 
-      test 'os should be updated for an existing template' do
+      test 'os/org/loc should be updated for an existing template' do
         ProvisioningTemplate.import!(@name, @text, @metadata)
 
         ct = ProvisioningTemplate.find_by_name(@name)
         assert_equal [@os_new], ct.operatingsystems
+        assert (ct.organization_ids.include? @new_org.id)
+        assert (ct.location_ids.include? @new_loc.id)
       end
     end
 
@@ -125,37 +137,23 @@ module ForemanTemplates
         @metadata['associate'] = 'never'
       end
 
-      test 'os should be unset for a new template' do
+      test 'os/org/loc should be unset for a new template' do
         name = 'Never Associate'
         ProvisioningTemplate.import!(name, @text, @metadata)
 
         ct = ProvisioningTemplate.find_by_name(name)
         assert_equal [], ct.operatingsystems
+        assert_equal [], ct.organization_ids
+        assert_equal [], ct.location_ids
       end
 
-      test 'os should be unchanged for an existing template' do
+      test 'os/org/loc should be unchanged for an existing template' do
         ProvisioningTemplate.import!(@name, @text, @metadata)
 
         ct = ProvisioningTemplate.find_by_name(@name)
         assert_equal [@os_old], ct.operatingsystems
-      end
-    end
-
-    context 'map_oses' do
-      test 'returns OSes that are in the db' do
-        metadata = { 'oses' => ['centos 5.3', 'Fedora 19'] }
-        assert_equal [Operatingsystem.find_by_title('centos 5.3')],
-                     ProvisioningTemplate.map_oses(metadata)
-      end
-
-      test 'returns an empty array for no matched OSes' do
-        metadata = { 'oses' => ['Fedora 19'] }
-        assert_equal [], ProvisioningTemplate.map_oses(metadata)
-      end
-
-      test 'defaults to an emtpy array' do
-        metadata = {}
-        assert_equal [], ProvisioningTemplate.map_oses(metadata)
+        assert (not ct.organization_ids.include? @new_org.id)
+        assert (not ct.location_ids.include? @new_loc.id)
       end
     end
   end

--- a/test/unit/ptable_test.rb
+++ b/test/unit/ptable_test.rb
@@ -4,16 +4,20 @@ module ForemanTemplates
   class PtableTest < ActiveSupport::TestCase
     setup do
       # create a basic template with no OS assigned
-      @os_rh  = FactoryGirl.create(:operatingsystem, :family => 'Redhat')
-      @os_deb = FactoryGirl.create(:operatingsystem, :family => 'Debian')
-      @pt     = FactoryGirl.create(:ptable, :os_family => 'Redhat')
+      @os_rh   = FactoryGirl.create(:operatingsystem, :family => 'Redhat')
+      @os_deb  = FactoryGirl.create(:operatingsystem, :family => 'Debian')
+      @pt      = FactoryGirl.create(:ptable, :os_family => 'Redhat')
+      @new_org = FactoryGirl.create(:organization, :name => 'NewOrg')
+      @new_loc = FactoryGirl.create(:location, :name => 'NewLoc')
 
       # Set up the data wanted by import!
       @name     = @pt.name
       @text     = @pt.template
       @metadata = {
         'oses'      => [@os_deb.to_label],
-        'associate' => 'new'
+        'associate' => 'new',
+        'organizations' => [@new_org.name], 
+        'locations' => [@new_loc.name] 
       }
     end
 
@@ -43,19 +47,23 @@ module ForemanTemplates
     end
 
     context 'when associate=new' do
-      test 'family should be set for a new ptable' do
+      test 'family/org/loc should be set for a new ptable' do
         name = 'New Associate'
         Ptable.import!(name, @text, @metadata)
 
         pt = Ptable.find_by_name(name)
         assert_equal @os_deb.family, pt.os_family
+        assert (pt.organization_ids.include? @new_org.id)
+        assert (pt.location_ids.include? @new_loc.id)
       end
 
-      test 'family should be unchanged for an existing ptable' do
+      test 'family/org/loc should be unchanged for an existing ptable' do
         Ptable.import!(@name, @text, @metadata)
 
         pt = Ptable.find_by_name(@name)
         assert_equal @os_rh.family, pt.os_family
+        assert (not pt.organization_ids.include? @new_org.id)
+        assert (not pt.location_ids.include? @new_loc.id)
       end
     end
 
@@ -64,19 +72,23 @@ module ForemanTemplates
         @metadata['associate'] = 'always'
       end
 
-      test 'family should be set for a new ptable' do
+      test 'family/org/loc should be set for a new ptable' do
         name = 'Always Associate'
         Ptable.import!(name, @text, @metadata)
 
         pt = Ptable.find_by_name(name)
         assert_equal @os_deb.family, pt.os_family
+        assert (pt.organization_ids.include? @new_org.id)
+        assert (pt.location_ids.include? @new_loc.id)
       end
 
-      test 'family should be updated for an existing ptable' do
+      test 'family/org/loc should be updated for an existing ptable' do
         Ptable.import!(@name, @text, @metadata)
 
         pt = Ptable.find_by_name(@name)
         assert_equal @os_deb.family, pt.os_family
+        assert (pt.organization_ids.include? @new_org.id)
+        assert (pt.location_ids.include? @new_loc.id)
       end
     end
 
@@ -85,19 +97,23 @@ module ForemanTemplates
         @metadata['associate'] = 'never'
       end
 
-      test 'family should be unset for a new ptable' do
+      test 'family/org/loc should be unset for a new ptable' do
         name = 'Never Associate'
         Ptable.import!(name, @text, @metadata)
 
         pt = Ptable.find_by_name(name)
         assert_nil pt.os_family
+        assert_equal [], pt.organization_ids
+        assert_equal [], pt.location_ids
       end
 
-      test 'family should be unchanged for an existing ptable' do
+      test 'family/org/loc should be unchanged for an existing ptable' do
         Ptable.import!(@name, @text, @metadata)
 
         pt = Ptable.find_by_name(@name)
         assert_equal @os_rh.family, pt.os_family
+        assert (not pt.organization_ids.include? @new_org.id)
+        assert (not pt.location_ids.include? @new_loc.id)
       end
     end
 
@@ -125,23 +141,6 @@ module ForemanTemplates
         s1 = Ptable.find_by_name(s.name)
         assert r[:diff].nil?
         assert_equal s.template, s1.template
-      end
-    end
-
-    context 'map_oses' do
-      test 'returns OSes that are in the db' do
-        metadata = { 'oses' => ['centos 5.3', 'Fedora 19'] }
-        assert_equal [Operatingsystem.find_by_title('centos 5.3')], Ptable.map_oses(metadata)
-      end
-
-      test 'returns an empty array for no matched OSes' do
-        metadata = { 'oses' => ['Fedora 19'] }
-        assert_equal [], Ptable.map_oses(metadata)
-      end
-
-      test 'defaults to an emtpy array' do
-        metadata = {}
-        assert_equal [], Ptable.map_oses(metadata)
       end
     end
   end

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -166,5 +166,46 @@ module ForemanTemplates
       assert ProvisioningTemplate.find_by_name('FooBar keep_me').present?
       assert ProvisioningTemplate.all.size, 1
     end # 'purge! removes expected template'
+
+    context 'map_metadata' do
+      test 'returns OSes that are in the db' do
+        metadata = { 'oses' => ['centos 5.3', 'Fedora 19'] }
+        assert_equal [Operatingsystem.find_by_title('centos 5.3')], Template.map_metadata(metadata, 'oses')
+      end
+
+      test 'returns Orgs that are in the db' do
+        metadata = { 'organizations' => ['Organization 1', 'Organization One'] }
+        assert_equal [Organization.find_by_name('Organization 1')],
+                     Template.map_metadata(metadata, 'organizations')
+      end
+
+      test 'returns Locations that are in the db' do
+        metadata = { 'locations' => ['Location 1', 'Location One'] }
+        assert_equal [Location.find_by_name('Location 1')],
+                     Template.map_metadata(metadata, 'locations')
+      end
+
+      test 'returns an empty array for no matched OSes' do
+        metadata = { 'oses' => ['Fedora 19'] }
+        assert_equal [], Template.map_metadata(metadata, 'oses')
+      end
+
+      test 'returns an empty array for no matched Org' do
+        metadata = { 'organizations' => ['Organization One'] }
+        assert_equal [], Template.map_metadata(metadata, 'organizations')
+      end
+
+      test 'returns an empty array for no matched Location' do
+        metadata = { 'locations' => ['Location One'] }
+        assert_equal [], Template.map_metadata(metadata, 'locations')
+      end
+
+      test 'map_metadata defaults to an emtpy array' do
+        metadata = {}
+        [ 'oses', 'locations', 'organizations' ].each do |param|
+          assert_equal [], Template.map_metadata(metadata, param)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for Organizations & Locations metadata. 
You can test with metadata:
```
locations:
- loc a
- loc b
organizations:
- org a
- org b
```