### PR TITLE
Fixes #17417 - adds exporting task

### DIFF
--- a/app/models/setting/template_sync.rb
+++ b/app/models/setting/template_sync.rb
@@ -25,7 +25,7 @@ class Setting::TemplateSync < Setting
       [
         self.set('template_sync_verbose', N_('Choose verbosity for Rake task importing templates'), false, N_('Verbosity')),
         self.set('template_sync_associate', N_('Associate templates to OS'), 'new', N_('Associate'), nil, { :collection => Proc.new { self.associate_types } }),
-        self.set('template_sync_prefix', N_('The string all imported or exported templates should begin with'), "Community ", N_('Prefix')),
+        self.set('template_sync_prefix', N_('The string all imported templates should begin with'), "Community ", N_('Prefix')),
         self.set('template_sync_dirname', N_('The directory within the Git repo containing the templates'), '/', N_('Dirname')),
         self.set('template_sync_filter', N_('Import or export names matching this regex (case-insensitive; snippets are not filtered)'), nil, N_('Filter')),
         self.set('template_sync_repo', N_('Default Git repo to sync from'), 'https://github.com/theforeman/community-templates.git', N_('Repo')),

--- a/app/models/setting/template_sync.rb
+++ b/app/models/setting/template_sync.rb
@@ -7,6 +7,15 @@ class Setting::TemplateSync < Setting
     }
   end
 
+  def self.metadata_export_mode_types
+    {
+      'refresh' => _('Refresh'),
+      'keep' => _('Keep'),
+      'remove' => _('Remove')
+    }
+  end
+
+
   def self.load_defaults
     return unless super
 
@@ -16,12 +25,13 @@ class Setting::TemplateSync < Setting
       [
         self.set('template_sync_verbose', N_('Choose verbosity for Rake task importing templates'), false, N_('Verbosity')),
         self.set('template_sync_associate', N_('Associate templates to OS'), 'new', N_('Associate'), nil, { :collection => Proc.new { self.associate_types } }),
-        self.set('template_sync_prefix', N_('The string all imported templates should begin with'), "Community ", N_('Prefix')),
+        self.set('template_sync_prefix', N_('The string all imported or exported templates should begin with'), "Community ", N_('Prefix')),
         self.set('template_sync_dirname', N_('The directory within the Git repo containing the templates'), '/', N_('Dirname')),
-        self.set('template_sync_filter', N_('Import names matching this regex (case-insensitive; snippets are not filtered)'), nil, N_('Filter')),
+        self.set('template_sync_filter', N_('Import or export names matching this regex (case-insensitive; snippets are not filtered)'), nil, N_('Filter')),
         self.set('template_sync_repo', N_('Default Git repo to sync from'), 'https://github.com/theforeman/community-templates.git', N_('Repo')),
-        self.set('template_sync_negate', N_('Negate the search'), false, N_('Negate')),
-        self.set('template_sync_branch', N_('Default branch in Git repo'), nil, N_('Branch'))
+        self.set('template_sync_negate', N_('Negate the prefix (for purging) / filter (for importing/exporting)'), false, N_('Negate')),
+        self.set('template_sync_branch', N_('Default branch in Git repo'), nil, N_('Branch')),
+        self.set('template_sync_metadata_export_mode', N_('Default metadata export mode, refresh re-renders metadata, keep will keep existing metadata, remove exports template withou metadata'), 'refresh', N_('Metadata export mode'), nil, { :collection => Proc.new { self.metadata_export_mode_types } })
       ].compact.each { |s| self.create! s.update(:category => "Setting::TemplateSync") }
     end
 
@@ -32,6 +42,13 @@ class Setting::TemplateSync < Setting
     values = record.class.associate_types.keys
     if record.value && !values.include?(record.value)
       record.errors[:base] << (_("template_sync_associate must be one of %s") % values.join(', '))
+    end
+  end
+
+  def validate_template_sync_metadata_export_mode(record)
+    values = record.class.metadata_export_mode_types.keys
+    if record.value && !values.include?(record.value)
+      record.errors[:base] << (_("template_sync_metadata_export_mode must be one of %s") % values.join(', '))
     end
   end
 end

--- a/app/services/foreman_templates/action.rb
+++ b/app/services/foreman_templates/action.rb
@@ -1,0 +1,44 @@
+module ForemanTemplates
+  class Action
+    delegate :logger, :to => :Rails
+
+    def self.setting_overrides
+      []
+    end
+
+    def method_missing(method, *args, &block)
+      if self.class.setting_overrides.include?(method)
+        instance_variable_get("@#{method}")
+      else
+        super
+      end
+    end
+
+    def repond_to_missing?(method, include_private = false)
+      self.class.setting_overrides.include?(method)
+    end
+
+    def initialize(args = {})
+      assign_attributes args
+    end
+
+    def get_default_branch(repo)
+      branch_names = repo.branches.map(&:name).uniq
+
+      # Always use develop on Foreman-nightly, if present, or else relevant stable branch
+      target = SETTINGS[:version].tag == 'develop' ? 'develop' : "#{SETTINGS[:version].short}-stable"
+      return target if branch_names.include?(target)
+
+      # stay on default branch as fallback
+      nil
+    end
+
+    private
+
+    def assign_attributes(args = {})
+      self.class.setting_overrides.each do |attribute|
+        instance_variable_set("@#{attribute}", args[attribute.to_sym] || Setting["template_sync_#{attribute}".to_sym])
+      end
+    end
+  end
+end

--- a/app/services/foreman_templates/action.rb
+++ b/app/services/foreman_templates/action.rb
@@ -3,7 +3,7 @@ module ForemanTemplates
     delegate :logger, :to => :Rails
 
     def self.setting_overrides
-      []
+      %i(verbose prefix dirname filter repo negate branch)
     end
 
     def method_missing(method, *args, &block)
@@ -31,6 +31,18 @@ module ForemanTemplates
 
       # stay on default branch as fallback
       nil
+    end
+
+    def git_repo?
+      @repo.start_with?('http://', 'https://', 'git://')
+    end
+
+    def get_absolute_repo_path
+      File.expand_path(@repo)
+    end
+
+    def verify_path!(path)
+      raise "Using file-based synchronization, but couldn't find #{path}" unless Dir.exist?(path)
     end
 
     private

--- a/app/services/foreman_templates/template_exporter.rb
+++ b/app/services/foreman_templates/template_exporter.rb
@@ -1,0 +1,78 @@
+module ForemanTemplates
+  class TemplateExporter < Action
+    def self.setting_overrides
+      %i(prefix dirname filter repo negate branch metadata_export_mode)
+    end
+
+    def export!
+      @dir = Dir.mktmpdir
+
+      git_repo = Git.clone(@repo, @dir)
+      logger.debug "cloned #{@repo} to #{@dir}"
+      branch = @branch ? @branch : get_default_branch(git_repo)
+      git_repo.checkout(branch) if branch
+
+      dump_files!
+
+      git_repo.add
+      logger.debug "commiting changes in cloned repo"
+      git_repo.commit "Templates export made by Foreman user #{User.current.try(:login) || User::ANONYMOUS_ADMIN}"
+      logger.debug "pushing to branch #{branch} at origin #{@repo}"
+      git_repo.push 'origin', branch
+
+      return true
+    ensure
+      FileUtils.remove_entry_secure(@dir) if File.exist?(@dir)
+    end
+
+    def dump_files!
+      templates_to_dump.map do |template|
+        current_dir = get_dump_dir(template)
+        FileUtils.mkdir_p current_dir
+
+        filename = File.join(current_dir, get_template_filename(template))
+        File.open(filename, 'w+') do |file|
+          logger.debug "Writing to file #{filename}"
+          bytes = file.write template.public_send(export_method)
+          logger.debug "finished writing #{bytes}"
+        end
+      end
+    end
+
+    def get_template_filename(template)
+      prefix.to_s + template.name.downcase.tr(' ', '_') + '.erb'
+    end
+
+    def get_dump_dir(template)
+      kind = template.respond_to?(:template_kind) ? template.template_kind.try(:name) || 'snippet' : nil
+      File.join(@dir, dirname.to_s, template.model_name.human.pluralize.downcase.tr(' ', '_'), kind.to_s)
+    end
+
+    def templates_to_dump
+      base = Template.all
+      if filter.present?
+        method = negate ? :reject : :select
+        base.public_send(method) { |template| template.name.match(/#{filter}/i) }
+      else
+        base
+      end
+    end
+
+    # * refresh - template.to_erb stripping existing metadata,
+    # * remove  - just template.template with stripping existing metadata,
+    # * keep    - taking the whole template.template
+    def export_method
+      case @metadata_export_mode
+        when 'refresh'
+          :to_erb
+        when 'remove'
+          :template_without_metadata
+        when 'keep'
+          :template
+        else
+          raise "Unknown metadata export mode #{@metadata_export_mode}"
+      end
+    end
+
+  end
+end

--- a/app/services/foreman_templates/template_importer.rb
+++ b/app/services/foreman_templates/template_importer.rb
@@ -66,7 +66,7 @@ module ForemanTemplates
         filename = template.split('/').last
         title    = filename.split('.').first
         name     = metadata['name'] || title
-        name     = [@prefix, name].compact.join
+        name     = auto_prefix(name)
         if @filter
           matching = name.match(/#{@filter}/i)
           matching = !matching if @negate
@@ -114,6 +114,10 @@ module ForemanTemplates
         end
       end
       result_lines
+    end
+
+    def auto_prefix(name)
+      name.start_with?(@prefix) ? name : [@prefix, name].compact.join
     end
 
     def calculate_diff(old, new)

--- a/app/services/foreman_templates/template_importer.rb
+++ b/app/services/foreman_templates/template_importer.rb
@@ -72,8 +72,6 @@ module ForemanTemplates
           next if !matching
         end
 
-        raise MissingKindError unless metadata['kind']
-
         begin
           # Expects a return of { :diff, :status, :result }
           data = if metadata['model'].present?

--- a/app/services/foreman_templates/template_importer.rb
+++ b/app/services/foreman_templates/template_importer.rb
@@ -2,18 +2,15 @@ class NoKindError < Exception; end
 class MissingKindError < Exception; end
 
 module ForemanTemplates
-  class TemplateImporter
-    delegate :logger, :to => :Rails
+  class TemplateImporter < Action
     attr_accessor :metadata, :name, :text
 
     def self.setting_overrides
       %i(verbose associate prefix dirname filter repo negate branch)
     end
 
-    attr_reader *setting_overrides
-
     def initialize(args = {})
-      assign_attributes args
+      super
       # Rake hands off strings, not booleans, and "false" is true...
       if @verbose.is_a?(String)
         @verbose = if @verbose == 'false'
@@ -70,7 +67,11 @@ module ForemanTemplates
         title    = filename.split('.').first
         name     = metadata['name'] || title
         name     = [@prefix, name].compact.join
-        next if @filter && !name.match(/#{@filter}/i)
+        if @filter
+          matching = name.match(/#{@filter}/i)
+          matching = !matching if @negate
+          next if !matching
+        end
 
         raise MissingKindError unless metadata['kind']
 
@@ -123,17 +124,6 @@ module ForemanTemplates
       end
     end
 
-    def get_default_branch(repo)
-      branch_names = repo.branches.map(&:name).uniq
-
-      # Always use develop on Foreman-nightly, if present, or else relevant stable branch
-      target = SETTINGS[:version].tag == 'develop' ? 'develop' : "#{SETTINGS[:version].short}-stable"
-      return target if branch_names.include?(target)
-
-      # stay on default branch as fallback
-      nil
-    end
-
     def parse_metadata(text)
       # Pull out the first erb comment only - /m is for a multiline regex
       extracted = text.match(/<%\#[\t a-z0-9=:]*(.+?).-?%>/m)
@@ -176,13 +166,5 @@ module ForemanTemplates
         template.destroy
       end
     end # :purge
-
-    private
-
-    def assign_attributes(args = {})
-      self.class.setting_overrides.each do |attribute|
-        instance_variable_set("@#{attribute}", args[attribute.to_sym] || Setting["template_sync_#{attribute}".to_sym])
-      end
-    end
   end
 end

--- a/app/services/foreman_templates/template_importer.rb
+++ b/app/services/foreman_templates/template_importer.rb
@@ -6,7 +6,7 @@ module ForemanTemplates
     attr_accessor :metadata, :name, :text
 
     def self.setting_overrides
-      %i(verbose associate prefix dirname filter repo negate branch)
+      super + %i(associate)
     end
 
     def initialize(args = {})
@@ -22,7 +22,7 @@ module ForemanTemplates
     end
 
     def import!
-      if @repo.start_with?('http://', 'https://', 'git://')
+      if git_repo?
         import_from_git
       else
         import_from_files
@@ -30,9 +30,8 @@ module ForemanTemplates
     end
 
     def import_from_files
-      abs_repo_path = File.expand_path @repo
-      return ["Using file-based import, but couldn't find #{abs_repo_path}"] unless Dir.exist?(abs_repo_path)
-      @dir = abs_repo_path
+      @dir = get_absolute_repo_path
+      verify_path!(@dir)
       return parse_files!
     end
 

--- a/lib/tasks/foreman_templates_tasks.rake
+++ b/lib/tasks/foreman_templates_tasks.rake
@@ -1,7 +1,10 @@
 # Tasks
 namespace :templates do
   desc 'Synchronize templates from a git repo'
-  task :sync => :environment do
+  task :import => :environment do
+    if Rake.application.top_level_tasks.include?('templates:sync')
+      ActiveSupport::Deprecation.warn('templates:sync task has been renamed to templates:import and will be removed in future version')
+    end
     # Available options:
     #* verbose   => Print extra information during the run [false]
     #* repo      => Sync templates from a different Git repo [https://github.com/theforeman/community-templates]
@@ -23,6 +26,8 @@ namespace :templates do
 
     puts results.join("\n")
   end
+
+  task :sync => :import
 
   desc 'Purge unwanted templates from foreman'
   task :purge => :environment do

--- a/lib/tasks/foreman_templates_tasks.rake
+++ b/lib/tasks/foreman_templates_tasks.rake
@@ -29,6 +29,21 @@ namespace :templates do
 
   task :sync => :import
 
+  task :export => :environment do
+    ForemanTemplates::TemplateExporter.new({
+      verbose:   ENV['verbose'],
+      repo: ENV['repo'],
+      branch: ENV['branch'],
+      prefix: ENV['prefix'],
+      dirname: ENV['dirname'],
+      filter: ENV['filter'],
+      # associate: ENV['associate'],
+      metadata_export_mode: ENV['metadata_export_mode'],
+    }).export!
+
+    puts 'Export finished'
+  end
+
   desc 'Purge unwanted templates from foreman'
   task :purge => :environment do
     ForemanTemplates::TemplateImporter.new({

--- a/lib/tasks/foreman_templates_tasks.rake
+++ b/lib/tasks/foreman_templates_tasks.rake
@@ -3,7 +3,7 @@ namespace :templates do
   desc 'Synchronize templates from a git repo'
   task :import => :environment do
     if Rake.application.top_level_tasks.include?('templates:sync')
-      ActiveSupport::Deprecation.warn('templates:sync task has been renamed to templates:import and will be removed in future version')
+      ActiveSupport::Deprecation.warn('templates:sync task has been renamed to templates:import and will be removed in a future version')
     end
     # Available options:
     #* verbose   => Print extra information during the run [false]

--- a/test/unit/action_test.rb
+++ b/test/unit/action_test.rb
@@ -53,5 +53,57 @@ module ForemanTemplates
       end
     end
 
+    context 'git_repo?' do
+      test 'it returns false for absolute path' do
+        refute Action.new(:repo => '/tmp').git_repo?
+      end
+
+      test 'it returns false for user home path' do
+        refute Action.new(:repo => '~user').git_repo?
+      end
+
+      test 'it return false for relative path' do
+        refute Action.new(:repo => 'tmp/').git_repo?
+      end
+
+      test 'it returns true for http url' do
+        assert Action.new(:repo => 'http://github.com').git_repo?
+      end
+
+      test 'it returns true for https url' do
+        assert Action.new(:repo => 'https://github.com').git_repo?
+      end
+
+      test 'it returns true for git url' do
+        assert Action.new(:repo => 'git://github.com').git_repo?
+      end
+    end
+
+    context 'get_absolute_path' do
+      test 'it keeps absolute paths' do
+        assert_equal Action.new(:repo => '/tmp').get_absolute_repo_path, '/tmp'
+      end
+
+      test 'it converts relative path to absolute' do
+        assert_equal '/', Action.new(:repo => 'tmp').get_absolute_repo_path.first
+      end
+    end
+
+    context 'verify_path!' do
+      test 'raises an exception if the path does not exists' do
+        assert_raises RuntimeError do
+          Action.new.verify_path!('/tmpfoobar')
+        end
+      end
+
+      test 'does not raise anything if the directory exist' do
+        Dir.mktmpdir do |dir|
+          assert_nothing_raised do
+            Action.new.verify_path!(dir)
+          end
+        end
+      end
+    end
+
   end
 end

--- a/test/unit/action_test.rb
+++ b/test/unit/action_test.rb
@@ -1,0 +1,57 @@
+require 'test_plugin_helper'
+
+module ForemanTemplates
+  class ActionTest < ActiveSupport::TestCase
+    context 'initialization of action' do
+      test '#initialize loads data from settings' do
+        Setting.stub(:[], '/tmp') do
+          ForemanTemplates::Action.stub(:setting_overrides, [ :directory ]) do
+            action = ForemanTemplates::Action.new
+            assert_equal '/tmp', action.instance_variable_get('@directory')
+          end
+        end
+      end
+
+      test '#initialize can be overriden by specific value' do
+        Setting.stub(:[], '/tmp') do
+          ForemanTemplates::Action.stub(:setting_overrides, [ :directory ]) do
+            action = ForemanTemplates::Action.new :directory => '/var/tmp'
+            assert_equal '/var/tmp', action.instance_variable_get('@directory')
+          end
+        end
+      end
+    end
+
+    test 'defines logger' do
+      Action.new.respond_to?(:logger)
+    end
+
+    context 'get_default_branch' do
+      setup do
+        @repo = Struct.new(:branches).new([
+                                            Struct.new(:name).new('0.1-stable'),
+                                            Struct.new(:name).new('develop')
+                                          ])
+        @action = Action.new
+      end
+
+      test 'when on develop, returns develop' do
+        SETTINGS[:version].stubs(:tag).returns('develop')
+        assert_equal 'develop', @action.get_default_branch(@repo)
+      end
+
+      test 'when branch exists, return it' do
+        SETTINGS[:version].stubs(:tag).returns('not_develop')
+        SETTINGS[:version].stubs(:short).returns('0.1')
+        assert_equal '0.1-stable', @action.get_default_branch(@repo)
+      end
+
+      test 'when branch does not exist, use default branch' do
+        SETTINGS[:version].stubs(:tag).returns('not_develop')
+        SETTINGS[:version].stubs(:short).returns('0.2')
+        refute @action.get_default_branch(@repo)
+      end
+    end
+
+  end
+end

--- a/test/unit/template_exporter_test.rb
+++ b/test/unit/template_exporter_test.rb
@@ -1,0 +1,83 @@
+require 'test_plugin_helper'
+
+module ForemanTemplates
+  class TemplateExporterTest < ActiveSupport::TestCase
+    before do
+      @exporter = TemplateExporter.new
+    end
+
+    describe '#templates_to_dump' do
+      before do
+        @template = FactoryGirl.create(:provisioning_template, :name => 'included')
+      end
+
+      test 'finds existing templates' do
+        assert_includes @exporter.templates_to_dump, @template
+      end
+
+      test 'finds templates based on filter' do
+        ignored = FactoryGirl.create(:provisioning_template, :name => 'not-included')
+        @exporter.stubs(:filter).returns('\Aincluded\Z')
+        @exporter.stubs(:negate).returns(false)
+        result = @exporter.templates_to_dump
+        assert_includes result, @template
+        refute_includes result, ignored
+      end
+
+      test 'filter can be negated' do
+        ignored = FactoryGirl.create(:provisioning_template, :name => 'not-included')
+        @exporter.stubs(:filter).returns('\Aincluded\Z')
+        @exporter.stubs(:negate).returns(true)
+        result = @exporter.templates_to_dump
+        refute_includes result, @template
+        assert_includes result, ignored
+      end
+    end
+
+    describe '#get_template_filename(template)' do
+      before do
+        @template = FactoryGirl.create(:provisioning_template, :name => 'template name')
+      end
+
+      test 'converts spaces to underscores and suffixes with .erb' do
+        assert_equal 'template_name.erb', @exporter.get_template_filename(@template)
+      end
+
+      test 'adds prefix' do
+        @exporter.stubs(:prefix).returns('[wip]')
+        assert_equal '[wip]template_name.erb', @exporter.get_template_filename(@template)
+      end
+    end
+
+    # kind = template.respond_to?(:template_kind) ? template.template_kind.try(:name) || 'snippet' : nil
+    # File.join(@dir, dirname, template.model_name.human.pluralize.downcase.tr(' ', '_'), kind.to_s)
+    describe '#get_dump_dir' do
+      before do
+        @template = FactoryGirl.create(:provisioning_template)
+      end
+
+      test 'underscores the model name based on type' do
+        @exporter.instance_variable_set('@dir', '/tmp')
+        assert_equal "/tmp/provisioning_templates/#{@template.template_kind.name}", @exporter.get_dump_dir(@template)
+      end
+
+      test 'appends template kind if the template knows it, defaulting to snippet' do
+        @exporter.instance_variable_set('@dir', '/tmp')
+        @template.template_kind.name = nil
+        assert_equal "/tmp/provisioning_templates/snippet", @exporter.get_dump_dir(@template)
+      end
+
+      test 'does not appends anything for template without kind' do
+        @exporter.instance_variable_set('@dir', '/tmp')
+        template = FactoryGirl.create(:ptable)
+        assert_equal "/tmp/ptables/", @exporter.get_dump_dir(template)
+      end
+
+      test 'appends configured dirname to temp dir' do
+        @exporter.instance_variable_set('@dir', '/tmp')
+        @exporter.stubs(:dirname).returns('extra_path')
+        assert_equal "/tmp/extra_path/provisioning_templates/#{@template.template_kind.name}", @exporter.get_dump_dir(@template)
+      end
+    end
+  end
+end

--- a/test/unit/template_exporter_test.rb
+++ b/test/unit/template_exporter_test.rb
@@ -42,11 +42,6 @@ module ForemanTemplates
       test 'converts spaces to underscores and suffixes with .erb' do
         assert_equal 'template_name.erb', @exporter.get_template_filename(@template)
       end
-
-      test 'adds prefix' do
-        @exporter.stubs(:prefix).returns('[wip]')
-        assert_equal '[wip]template_name.erb', @exporter.get_template_filename(@template)
-      end
     end
 
     # kind = template.respond_to?(:template_kind) ? template.template_kind.try(:name) || 'snippet' : nil

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -26,32 +26,6 @@ module ForemanTemplates
       @importer = importer
     end
 
-    context 'get_default_branch' do
-      setup do
-        @repo = Struct.new(:branches).new([
-                                            Struct.new(:name).new('0.1-stable'),
-                                            Struct.new(:name).new('develop')
-                                          ])
-      end
-
-      test 'when on develop, returns develop' do
-        SETTINGS[:version].stubs(:tag).returns('develop')
-        assert_equal 'develop', @importer.get_default_branch(@repo)
-      end
-
-      test 'when branch exists, return it' do
-        SETTINGS[:version].stubs(:tag).returns('not_develop')
-        SETTINGS[:version].stubs(:short).returns('0.1')
-        assert_equal '0.1-stable', @importer.get_default_branch(@repo)
-      end
-
-      test 'when branch does not exist, use default branch' do
-        SETTINGS[:version].stubs(:tag).returns('not_develop')
-        SETTINGS[:version].stubs(:short).returns('0.2')
-        refute @importer.get_default_branch(@repo)
-      end
-    end
-
     context 'metadata method' do
       test 'extracts correct metadata' do
         text = File.read(get_template('metadata1.erb'))

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -235,6 +235,12 @@ module ForemanTemplates
       assert_equal succ, res.first
     end
 
+    test '#auto_prefix' do
+      assert_equal 'FooBar something', @importer.auto_prefix('something')
+      assert_equal 'FooBar something', @importer.auto_prefix('FooBar something')
+      assert_equal 'FooBar template FooBar something', @importer.auto_prefix('template FooBar something')
+    end
+
     private
 
     def setup_settings(opts = {})

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -217,12 +217,14 @@ module ForemanTemplates
       assert_equal succ, res.first
     end
 
-    test 'should fail gracefully when cannot find path on filesystem' do
+    test 'should fail with exception when cannot find path on filesystem' do
       some_dir = File.expand_path(File.join('..', '..', '..', 'some_dir'), __FILE__)
       setup_settings :repo => some_dir
       imp = ForemanTemplates::TemplateImporter.new
-      res = imp.import!
-      assert_equal "Using file-based import, but couldn't find #{File.expand_path(some_dir)}", res.first
+      assert_raises RuntimeError do |exception|
+        imp.import!
+        assert_equal exception.message, "Using file-based import, but couldn't find #{File.expand_path(some_dir)}"
+      end
     end
 
     test 'should be able to use ~ in path' do


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/4031 but other than that, ready for review. I didn't cover it in readme since I'd like to write a proper manual for the plugin and start linking there. If you want to test, run `rake templates:export`. Just be careful, currently it clones remote repo, does changes, creates commit and pushes to the origin. After discussion with @xprazak2 we decided to leave it like this until there's a filesystem support (https://github.com/theforeman/foreman_templates/pull/35). Later we'd like to introduce repos as first class citizen object that users could configure separately.