### PR TITLE
Fixes #17583 - Provide an API to initiate a sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .idea
+Gemfile.lock

--- a/app/controllers/api/v2/template_controller.rb
+++ b/app/controllers/api/v2/template_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  module V2
+    class TemplateController < ::Api::V2::BaseController
+
+      api :POST, "/template/import/", N_("Initiate Import")
+      param :repo, String, :required => false, :desc => N_("Import templates from a different repo.")
+      param :branch, String, :required => false, :desc => N_("Branch in Git repo.")
+      param :prefix, String, :required => false, :desc => N_("The string all imported templates should begin with.")
+      param :dirname, String, :required => false, :desc => N_("The directory within the git tree containing the templates.")
+      param :filter, String, :required => false, :desc => N_("Import names matching this regex (case-insensitive; snippets are not filtered).")
+      param :negate, :bool, :required => false, :desc => N_("Negate the prefix (for purging).")
+      param :associate, String, :required => false, :desc => N_("Associate to OS's, Locations & Organizations. Options are: always, new or never.")
+      def import
+        results = ForemanTemplates::TemplateImporter.new({
+          verbose:   params['verbose'],
+          repo:      params['repo'],
+          branch:    params['branch'],
+          prefix:    params['prefix'],
+          dirname:   params['dirname'],
+          filter:    params['filter'],
+          associate: params['associate'],
+          negate:    params['negate'],
+        }).import!
+        render :json => {:message => results}
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,13 @@
+Rails.application.routes.draw do
+
+  namespace :api, :defaults => {:format => 'json'} do
+    scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2) do
+      resources :templates, :controller => :template, :only => :import do
+        collection do
+          post 'import'
+        end
+      end
+    end
+  end
+
+end

--- a/lib/foreman_templates/engine.rb
+++ b/lib/foreman_templates/engine.rb
@@ -15,7 +15,16 @@ module ForemanTemplates
 
     initializer 'foreman_templates.register_plugin', :before => :finisher_hook do
       Foreman::Plugin.register :foreman_templates do
-        requires_foreman '>= 1.14'
+        requires_foreman '>= 1.15'
+
+        apipie_documented_controllers ["#{ForemanTemplates::Engine.root}/app/controllers/api/v2/*.rb"]
+
+        security_block :templates do
+          permission :import_templates, {
+            :"api/v2/template" => [:import]
+          }, :resource_type => 'Template'
+        end
+        add_all_permissions_to_default_roles
       end
     end
 

--- a/test/functional/api/v2/template_controller_test.rb
+++ b/test/functional/api/v2/template_controller_test.rb
@@ -1,0 +1,10 @@
+require 'test_plugin_helper'
+
+class Api::V2::TemplateControllerTest < ActionController::TestCase
+
+  test "should import from git" do
+    post :import, { 'repo': "#{ForemanTemplates::Engine.root}/test/templates/core", 'prefix': ''}
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
You should be able to test it with:
```
curl -H "Accept:application/json,version=2" -H "Content-Type:application/json" -u admin:changeme -k https://centos7-devel.example.com/api/v2/templates/import -X POST -d ''
```