### PR TITLE
Adding button to sync foreman templates using a foreman task

### DIFF
--- a/app/controllers/templates_sync_controller.rb
+++ b/app/controllers/templates_sync_controller.rb
@@ -1,0 +1,13 @@
+class TemplatesSyncController < ApplicationController
+  def sync
+    begin
+      ForemanTasks.async_task(::Actions::TemplatesSync::Sync)
+      notice _("Added sync foreman templates task to queue, it will be run shortly.")
+
+    rescue ::Foreman::Exception => e
+      error _("Failed to add task to queue: %s") % e.to_s
+    ensure
+      redirect_to settings_path(:anchor => "TemplateSync")
+    end
+  end
+end

--- a/app/lib/actions/templates_sync/sync.rb
+++ b/app/lib/actions/templates_sync/sync.rb
@@ -1,0 +1,33 @@
+module Actions
+  module TemplatesSync
+    class Sync < Actions::Base
+
+      def plan
+        ::Foreman::Logging.logger('foreman_templates').info "Initiating 'sync' for templates."
+
+        # Make sure we don't have two concurrent listening services competing
+        if already_running?
+          fail "Action #{self.class.name} is already active"
+        end
+        plan_self
+      end
+
+      def run
+        ::Foreman::Logging.logger('foreman_templates').info "Running 'sync' for templates."
+        output[:data] = ForemanTemplates::TemplateImporter.new({
+          verbose: true,
+        }).import!
+        output[:data].join("\n")
+      end
+
+      def humanized_name
+        _("Sync Foreman Templates")
+      end
+
+      # default value for cleaning up the tasks, it can be overriden by settings
+      def self.cleanup_after
+        '30d'
+      end
+    end
+  end
+end

--- a/app/views/settings/category/_templatesync.html.erb
+++ b/app/views/settings/category/_templatesync.html.erb
@@ -1,0 +1,16 @@
+<%= javascript_tag do %>
+var ready;
+
+ready = function() {
+  var hash = window.location.hash;
+  hash && $('ul.nav a[href="' + hash + '"]').tab('show');
+};
+
+$(document).ready(ready);
+$(document).on('page:load', ready);
+<% end %>
+<%= display_link_if_authorized(_("Sync templates"), { :controller => 'templates_sync', :action => :sync },
+  :title => _("Sync the templates now"), 
+  :id => "sync_templates_button", 
+  :class =>"btn btn-success") %>
+<%= content_tag(:br) %>


### PR DESCRIPTION
Adding a button to foreman_templates which does start the sync (import) of templates in a async foreman task. 
