### PR TITLE
Fixes #19555 - Add a setting to bypass template locks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/MethodLength:
   Max: 20
 
 Metrics/LineLength:
-  Enabled: false 
+  Enabled: false
 
 Style/Next:
   Enabled: false
@@ -97,6 +97,9 @@ Metrics/BlockLength:
   Max: 47
 Metrics/PerceivedComplexity:
   Max: 20
+
+Metrics/ParameterLists:
+  Max: 6
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/app/controllers/api/v2/template_controller.rb
+++ b/app/controllers/api/v2/template_controller.rb
@@ -9,6 +9,7 @@ module Api
       param :filter, String, :required => false, :desc => N_("Import names matching this regex (case-insensitive; snippets are not filtered).")
       param :negate, :bool, :required => false, :desc => N_("Negate the prefix (for purging).")
       param :associate, String, :required => false, :desc => N_("Associate to OS's, Locations & Organizations. Options are: always, new or never.")
+      param :force, :bool, :required => false, :desc => N_("Update templates that are locked")
       def import
         results = ForemanTemplates::TemplateImporter.new({
           verbose:   params['verbose'],
@@ -19,6 +20,7 @@ module Api
           filter:    params['filter'],
           associate: params['associate'],
           negate:    params['negate'],
+          force:     params['force']
         }).import!
         render :json => { :message => results }
       end

--- a/app/models/concerns/foreman_templates/provisioning_template_import.rb
+++ b/app/models/concerns/foreman_templates/provisioning_template_import.rb
@@ -3,9 +3,9 @@ module ForemanTemplates
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def import!(name, text, metadata)
+      def import!(name, text, metadata, force = false)
         # Check for snippet type
-        return import_snippet!(name, text) if metadata['snippet'] || metadata['kind'] == 'snippet'
+        return import_snippet!(name, text, force) if metadata['snippet'] || metadata['kind'] == 'snippet'
 
         # Get template type
         kind = TemplateKind.find_by(name: metadata['kind'])
@@ -23,39 +23,71 @@ module ForemanTemplates
         organizations = map_metadata(metadata, 'organizations')
 
         # Printout helpers
-        c_or_u = template.new_record? ? 'Created' : 'Updated'
-        id_string = ('id' + template.id) rescue ''
+        c_or_u = template.new_record? ? 'Creating' : 'Updating'
+        id_string = template.new_record? ? '' : "id #{template.id}"
+        if template.locked? && !template.new_record? && !force
+          return { :diff => nil,
+                   :status => false,
+                   :result => "Skipping Template #{id_string}:#{name} - template is locked" }
+        end
 
+        associate_metadata data, template, metadata, oses, organizations, locations
+
+        diff = nil
+        status = nil
+        if template_changed?(data, template)
+          diff = create_diff(data, template)
+          template.ignore_locking do
+            status = template.update_attributes(data)
+          end
+          result = build_associations_result c_or_u, id_string, name, oses, organizations, locations
+        else
+          status  = true
+          result  = "  No change to Template #{id_string}:#{name}"
+        end
+
+        { :diff => diff, :status => status, :result => result, :errors => template.errors }
+      end
+
+      def associate_metadata(data, template, metadata, oses, organizations, locations)
         if (metadata['associate'] == 'new' && template.new_record?) || (metadata['associate'] == 'always')
           data[:operatingsystem_ids] = oses.map(&:id)
           data[:location_ids]        = locations.map(&:id)
           data[:organization_ids]    = organizations.map(&:id)
         end
+        data
+      end
 
-        if data[:template] != template.template
-          diff = Diffy::Diff.new(
+      def build_associations_result(c_or_u, id_string, name, oses, organizations, locations)
+        res  = "  #{c_or_u} Template #{id_string}:#{name}"
+        res += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
+        res += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
+        res += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
+        res
+      end
+
+      def create_diff(data, template)
+        if template_content_changed?(template.template, data[:template])
+          Diffy::Diff.new(
             template.template,
             data[:template],
             :include_diff_info => true
           ).to_s(:color)
-          status  = template.update_attributes(data)
-          result  = "  #{c_or_u} Template #{id_string}:#{name}"
-          result += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
-          result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
-          result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
-        elsif data[:operatingsystem_ids] || data[:location_ids] || data[:organization_ids]
-          diff    = nil
-          status  = template.update_attributes(data)
-          result  = "  #{c_or_u} Template Associations #{id_string}:#{name}"
-          result += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
-          result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
-          result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
         else
-          diff    = nil
-          status  = true
-          result  = "  No change to Template #{id_string}:#{name}"
+          nil
         end
-        { :diff => diff, :status => status, :result => result }
+      end
+
+      def template_content_changed?(template_template, data_template)
+        template_template != data_template
+      end
+
+      def associations_changed?(data)
+        !(data[:operatingsystem_ids] || data[:location_ids] || data[:organization_ids]).nil?
+      end
+
+      def template_changed?(data, template)
+        template_content_changed?(template.template, data[:template]) || associations_changed?(data)
       end
     end
   end

--- a/app/models/concerns/foreman_templates/ptable_import.rb
+++ b/app/models/concerns/foreman_templates/ptable_import.rb
@@ -3,9 +3,9 @@ module ForemanTemplates
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def import!(name, text, metadata)
+      def import!(name, text, metadata, force = false)
         # Check for snippet type
-        return import_snippet!(name, text) if metadata['snippet']
+        return import_snippet!(name, text, force) if metadata['snippet']
 
         # Data
         ptable = Ptable.where(:name => name).first_or_initialize
@@ -17,42 +17,72 @@ module ForemanTemplates
         organizations = map_metadata(metadata, 'organizations')
 
         # Printout helpers
-        c_or_u = ptable.new_record? ? 'Created' : 'Updated'
-        id_string = ('id' + ptable.id) rescue ''
+        c_or_u = ptable.new_record? ? 'Creating' : 'Updating'
+        id_string = ptable.new_record? ? '' : "id #{ptable.id}"
+        if ptable.locked? && !ptable.new_record? && !force
+          return { :diff => nil,
+                   :status => false,
+                   :result => "Skipping Partition Table #{id_string}:#{name} - partition table is locked" }
+        end
 
+        associate_metadata data, ptable, metadata, oses, organizations, locations
+
+        diff = nil
+        status = nil
+        if ptable_changed?(data, ptable)
+          diff = create_diff(data, ptable)
+          ptable.ignore_locking do
+            status = ptable.update_attributes(data)
+          end
+          result  = build_associations_result c_or_u, id_string, name, oses, organizations, locations
+        else
+          status  = true
+          result  = "  No change to Ptable #{id_string}:#{name}"
+        end
+        { :diff => diff, :status => status, :result => result, :errors => ptable.errors }
+      end
+
+      def associate_metadata(data, ptable, metadata, oses, organizations, locations)
         if (metadata['associate'] == 'new' && ptable.new_record?) || (metadata['associate'] == 'always')
           data[:operatingsystem_ids] = oses.map(&:id)
           data[:os_family]           = oses.map(&:family).uniq.first
           data[:location_ids]        = locations.map(&:id)
           data[:organization_ids]    = organizations.map(&:id)
         end
+        data
+      end
 
-        if data[:layout] != ptable.layout
-          diff = Diffy::Diff.new(
+      def ptable_content_changed?(data_layout, ptable_layout)
+        data_layout != ptable_layout
+      end
+
+      def associations_changed?(data)
+        !(data[:os_family] || data[:location_ids] || data[:organization_ids]).nil?
+      end
+
+      def create_diff(data, ptable)
+        if ptable_content_changed?(data[:layout], ptable.layout)
+          Diffy::Diff.new(
             ptable.layout,
             data[:layout],
             :include_diff_info => true
           ).to_s(:color)
-          status  = ptable.update_attributes(data)
-          result  = "  #{c_or_u} Ptable #{id_string}:#{name}"
-          result += "\n    Operatingsystem Family:\n    - #{oses.map(&:family).uniq.first}" unless oses.empty?
-          result += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
-          result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
-          result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
-        elsif data[:os_family] || data[:location_ids] || data[:organization_ids]
-          diff    = nil
-          status  = ptable.update_attributes(data)
-          result  = "  #{c_or_u} Ptable Associations #{id_string}:#{name}"
-          result += "\n    Operatingsystem Family:\n    - #{oses.map(&:family).uniq.first}" unless oses.empty?
-          result += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
-          result += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
-          result += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
         else
-          diff    = nil
-          status  = true
-          result  = "  No change to Ptable #{id_string}:#{name}"
+          nil
         end
-        { :diff => diff, :status => status, :result => result }
+      end
+
+      def build_associations_result(c_or_u, id_string, name, oses, organizations, locations)
+        res  = "  #{c_or_u} Ptable #{id_string}:#{name}"
+        res += "\n    Operatingsystem Family:\n    - #{oses.map(&:family).uniq.first}" unless oses.empty?
+        res += "\n    Operatingsystem Associations:\n    - #{oses.map(&:fullname).join("\n    - ")}" unless oses.empty?
+        res += "\n    Organizations Associations:\n    - #{organizations.map(&:name).join("\n    - ")}" unless organizations.empty?
+        res += "\n    Location Associations:\n    - #{locations.map(&:name).join("\n    - ")}" unless locations.empty?
+        res
+      end
+
+      def ptable_changed?(data, ptable)
+        ptable_content_changed?(data[:layout], ptable.layout) || associations_changed?(data)
       end
     end
   end

--- a/app/models/concerns/foreman_templates/template_import.rb
+++ b/app/models/concerns/foreman_templates/template_import.rb
@@ -3,7 +3,7 @@ module ForemanTemplates
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def import_snippet!(name, text)
+      def import_snippet!(name, text, force = false)
         # Data
         snippet = self.where(:name => name).first_or_initialize
         data = {
@@ -12,23 +12,32 @@ module ForemanTemplates
         }
 
         # Printout helpers
-        c_or_u = snippet.new_record? ? 'Created' : 'Updated'
-        id_string = ('id' + snippet.id) rescue ''
+        c_or_u = snippet.new_record? ? 'Creating' : 'Updating'
+        id_string = snippet.new_record? ? '' : "id #{snippet.id}"
 
+        if snippet.locked? && !snippet.new_record? && !force
+          return { :diff => nil,
+                   :status => false,
+                   :result => "Skipping snippet #{id_string}:#{name} - template is locked" }
+        end
+
+        status = nil
         if data[:template] != snippet.template
           diff = Diffy::Diff.new(
             snippet.template,
             data[:template],
             :include_diff_info => true
           ).to_s(:color)
-          status  = snippet.update_attributes(data)
+          snippet.ignore_locking do
+            status = snippet.update_attributes(data)
+          end
           result  = "  #{c_or_u} Snippet #{id_string}:#{name}"
         else
           diff    = nil
           status  = true
           result  = "  No change to Snippet #{id_string}:#{name}"
         end
-        { :diff => diff, :status => status, :result => result }
+        { :diff => diff, :status => status, :result => result, :errors => snippet.errors }
       end
 
       def map_metadata(metadata, param)
@@ -40,11 +49,11 @@ module ForemanTemplates
             end.flatten.compact
           when 'locations'
             metadata[param].map do |loc|
-              Location.all.map { |db| db.name =~ /^#{loc}/ ? db : nil }
+              User.current.my_locations.map { |db| db.name =~ /^#{loc}/ ? db : nil }
             end.flatten.compact
           when 'organizations'
             metadata[param].map do |org|
-              Organization.all.map { |db| db.name =~ /^#{org}/ ? db : nil }
+              User.current.my_organizations.map { |db| db.name =~ /^#{org}/ ? db : nil }
             end.flatten.compact
           end
         else

--- a/app/models/setting/template_sync.rb
+++ b/app/models/setting/template_sync.rb
@@ -31,7 +31,8 @@ class Setting
           self.set('template_sync_repo', N_('Default Git repo to sync from'), 'https://github.com/theforeman/community-templates.git', N_('Repo')),
           self.set('template_sync_negate', N_('Negate the prefix (for purging) / filter (for importing/exporting)'), false, N_('Negate')),
           self.set('template_sync_branch', N_('Default branch in Git repo'), nil, N_('Branch')),
-          self.set('template_sync_metadata_export_mode', N_('Default metadata export mode, refresh re-renders metadata, keep will keep existing metadata, remove exports template withou metadata'), 'refresh', N_('Metadata export mode'), nil, { :collection => Proc.new { self.metadata_export_mode_types } })
+          self.set('template_sync_metadata_export_mode', N_('Default metadata export mode, refresh re-renders metadata, keep will keep existing metadata, remove exports template withou metadata'), 'refresh', N_('Metadata export mode'), nil, { :collection => Proc.new { self.metadata_export_mode_types } }),
+          self.set('template_sync_force', N_('Should importing overwrite locked templates?'), false, N_('Force import')),
         ].compact.each { |s| self.create! s.update(:category => "Setting::TemplateSync") }
       end
 

--- a/test/templates/locking/core_initial/metadata1.erb
+++ b/test/templates/locking/core_initial/metadata1.erb
@@ -1,0 +1,10 @@
+something
+<%#
+kind: provision
+name: Test Data
+%>
+foo
+
+bar
+<%# another comment %>
+quux

--- a/test/templates/locking/core_initial/ptable1.erb
+++ b/test/templates/locking/core_initial/ptable1.erb
@@ -1,0 +1,5 @@
+<%#
+kind: ptable
+name: Test Ptable
+%>
+test ptable layout

--- a/test/templates/locking/core_initial/snippet1.erb
+++ b/test/templates/locking/core_initial/snippet1.erb
@@ -1,0 +1,5 @@
+<%#
+kind: snippet
+name: Test Snippet
+%>
+some snippet text

--- a/test/templates/locking/core_updated/metadata1.erb
+++ b/test/templates/locking/core_updated/metadata1.erb
@@ -1,0 +1,11 @@
+something
+<%#
+kind: provision
+name: Test Data
+%>
+foo
+baz
+bar
+<%# another comment %>
+quux
+small squid

--- a/test/templates/locking/core_updated/ptable1.erb
+++ b/test/templates/locking/core_updated/ptable1.erb
@@ -1,0 +1,5 @@
+<%#
+kind: ptable
+name: Test Ptable
+%>
+test ptable layout updated

--- a/test/templates/locking/core_updated/snippet1.erb
+++ b/test/templates/locking/core_updated/snippet1.erb
@@ -1,0 +1,5 @@
+<%#
+kind: snippet
+name: Test Snippet
+%>
+some snippet text with crazy modifications


### PR DESCRIPTION
I created a new setting that allows bypassing the template lock, default value is false (do not update locked templates). It can be changed in the same way as any other setting for foreman_templates. 

I managed to improve messages a bit, users will know if template was skipped because it was locked. There is also something like:
```
template.errors if template.errors.any?
```
in the output, which is not very nice, but at least gives a hint what went wrong.

When executing import as non-admin user in an organization, user's org must be specified. Otherwise, there is  `Invalid organizations selection, you must select at least one of yours` error. When template has orgs in metadata that the user is not assigned to, they are ignored - template is associated only with user's organization. Same goes for locations.

When there is `OrgA` with template `some_tmpl` and `b_user` (user only in `OrgB`) tries to import `some_tmpl` (which is not yet present in `OrgB`), it failes with `name has already been taken`. This is a general problem with taxonomies - `some_tmpl` is not found for update in scope of `OrgB` and when we try to create it, we hit the unique constraint on name that is not scoped by taxonomy. 

I also managed to split the `import!` method a bit, but there is still a lot of duplicated code. I am not sure if further refactoring is worth the effort since we need to change the error handling and feedback to user.

~~TODO: tests~~

