### PR TITLE
Refs #19576 - Avoid using assert_equal for nil

### DIFF
--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -186,6 +186,7 @@ module ForemanTemplates
       setup_settings
       imp = ForemanTemplates::TemplateImporter.new
       imp.class.setting_overrides.each do |attribute|
+        next if assert_both_equal_nil imp.public_send(attribute), Setting["template_sync_#{attribute}".to_sym]
         assert_equal imp.public_send(attribute), Setting["template_sync_#{attribute}".to_sym]
       end
     end
@@ -258,6 +259,16 @@ module ForemanTemplates
       FactoryGirl.create(:setting, :settings_type => "string", :category => category, :name => 'template_sync_repo', :default => default_repo)
       FactoryGirl.create(:setting, :settings_type => "boolean", :category => category, :name => 'template_sync_negate', :default => false)
       FactoryGirl.create(:setting, :settings_type => "string", :category => category, :name => 'template_sync_branch', :default => default_branch)
+    end
+
+    def assert_both_equal_nil(expected, actual)
+      if expected.nil? || actual.nil?
+        assert_nil expected
+        assert_nil actual
+        true
+      else
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
Jenkins is still red, this should fix the one remaining failure. We should avoid using `assert_equal` with `nil` in the future as it is now [deprecated](https://github.com/seattlerb/minitest/blob/master/lib/minitest/assertions.rb#L180-L183) 