### PR TITLE
[WIP] Add rubocop-based validations task for templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "http://rubygems.org"
 
 gemspec
-gem 'rubocop'

--- a/app/services/foreman_templates/erb_strip.rb
+++ b/app/services/foreman_templates/erb_strip.rb
@@ -1,0 +1,31 @@
+module ForemanTemplates
+  class ErbStrip
+    ERB_REGEX = /(?<start_tag><%[-=]?)(?<script>([^#]).*?)(?<end_tag>-?%>)/m
+
+    def initialize(source)
+      @source = source
+    end
+
+    def strip
+      out = ''
+      current_position = 0
+      while (match = next_erb(current_position))
+        out << fill_newlines(current_position, match.begin(2) - 1)
+        out << match[:script]
+        out << ';'
+        out << ' ' * (match[:end_tag].length - 1)
+        current_position = match.end(3)
+      end
+      out
+    end
+
+    def next_erb(start_pos)
+      @source.match(ERB_REGEX, start_pos)
+    end
+
+    def fill_newlines(start, finish)
+      newlines = @source[start..finish].split("\n")
+      newlines.map { |line| ' ' * line.length }.join("\n")
+    end
+  end
+end

--- a/app/services/foreman_templates/rubocop_json_processor.rb
+++ b/app/services/foreman_templates/rubocop_json_processor.rb
@@ -1,0 +1,44 @@
+require 'json'
+
+module ForemanTemplates
+  class RubocopJsonProcessor
+    def initialize(json_file)
+      @report = JSON.parse(File.read(json_file))
+    end
+
+    def to_clang
+      @report['files'].each do |file_report|
+        report_file(file_report['path'], file_report['offenses'])
+      end
+    end
+
+    private
+
+    def report_file(filename, offenses)
+      report "File: \"#{filename}\""
+      buffer = File.read(filename)
+      lines = buffer.split("\n")
+
+      offenses.each do |offense_report|
+        report_offense(lines, offense_report)
+      end
+    end
+
+    def report_offense(lines, offense)
+      report "Message: #{offense['message']}"
+      report 'Source:'
+      report_source(lines, offense['location'])
+    end
+
+    def report_source(lines, location)
+      report lines[location['line'] - 1]
+
+      highlight = (' ' * (location['column'] - 1)) + ('^' * location['length'])
+      report highlight
+    end
+
+    def report(line)
+      puts line
+    end
+  end
+end

--- a/foreman_templates.gemspec
+++ b/foreman_templates.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "diffy"
   s.add_dependency "git"
+  s.add_dependency "rubocop"
 end

--- a/lib/rubocop/foreman_callback_cop.rb
+++ b/lib/rubocop/foreman_callback_cop.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Foreman
+      # This cop checks for calls to foreman_url without params
+      class ForemanUrl < Cop
+        MSG = 'Call foreman_url with (\'built\') `%s`.'.freeze
+
+        def_node_matcher :foreman_url_call?, <<-PATTERN
+          (send nil :foreman_url)
+        PATTERN
+
+        def on_send(node)
+          return unless foreman_url_call?(node)
+
+          add_offense(node, :expression)
+        end
+
+        private
+
+        def message(node)
+          format(MSG, node.source)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/foreman_erb_monkey_patch.rb
+++ b/lib/rubocop/foreman_erb_monkey_patch.rb
@@ -1,0 +1,12 @@
+# RuboCop::TargetFinder.new(nil)
+
+module RuboCop
+  class TargetFinder
+    def ruby_file_with_erb?(file)
+      ruby_file_without_erb?(file) || File.extname(file) == '.erb'
+    end
+
+    alias_method :ruby_file_without_erb?, :ruby_file?
+    alias_method :ruby_file?, :ruby_file_with_erb?
+  end
+end

--- a/lib/tasks/foreman_templates_development_tasks.rake
+++ b/lib/tasks/foreman_templates_development_tasks.rake
@@ -1,0 +1,35 @@
+# Tests
+namespace :test do
+  desc "Test ForemanTemplates"
+  Rake::TestTask.new(:foreman_templates) do |t|
+    test_dir = File.join(File.dirname(__FILE__), '../..', 'test')
+    t.libs << ['test', test_dir]
+    t.pattern = "#{test_dir}/**/*_test.rb"
+    t.verbose = true
+    t.warning = false
+  end
+end
+
+namespace :foreman_templates do
+  task :rubocop do
+    begin
+      require 'rubocop/rake_task'
+      RuboCop::RakeTask.new(:rubocop_foreman_templates) do |task|
+        task.patterns = ["#{ForemanTemplates::Engine.root}/app/**/*.rb",
+                         "#{ForemanTemplates::Engine.root}/lib/**/*.rb",
+                         "#{ForemanTemplates::Engine.root}/test/**/*.rb"]
+      end
+    rescue
+      puts 'Rubocop not loaded.'
+    end
+
+    Rake::Task['rubocop_foreman_templates'].invoke
+  end
+end
+
+Rake::Task[:test].enhance ['test:foreman_templates']
+
+load 'tasks/jenkins.rake'
+if Rake::Task.task_defined?(:'jenkins:unit')
+  Rake::Task['jenkins:unit'].enhance ['test:foreman_templates', 'foreman_templates:rubocop']
+end


### PR DESCRIPTION
This PR adds a new rake task that will be able to validate provisioning templates to see if they comply to the latest template writing policy.
This should be extremely useful when foreman upgrade changes the way templates should be written. This could be used as an alternative to a migration, so the user will know what changes should be done to his custom templates.

## Usage

``` sh
rake templates:validate path/to/template/file.erb
```

As a developer, the only thing that should be done, is writing a new cop into `rubocop` folder.

## Algorithm
Currently the task works on a single source template file.
First it strips erb from any text that should not be evaluated as ruby and puts the result into a temporary file. It leaves every character at its original place, so when rubocop reports errors, they could easily be referenced in the original file (Done by `erb_strip.rb`).
Next rubocop is invoked to examine this file and put the result as JSON in another temp file.
Last step is cross-referencing rubocop results with the original template and outputting all offences in an appropriate format.

## TODO
 - [ ] Move rubocop invocation to task
 - [ ] Make list of all cops in `rubocop/` folder to add to rubocop
 - [ ] Create a config file instead of `--only` option.
