### PR TITLE
Fix template import to respect custom branch

### DIFF
--- a/app/services/foreman_templates/template_importer.rb
+++ b/app/services/foreman_templates/template_importer.rb
@@ -36,7 +36,16 @@ module ForemanTemplates
       begin
         gitrepo = Git.clone(@repo, @dir)
         branch = @branch ? @branch : get_default_branch(gitrepo)
-        gitrepo.checkout(branch) if branch
+        if branch
+          if gitrepo.is_branch?(branch)
+            gitrepo.checkout(branch)
+          else
+            gitrepo.branch(branch).checkout
+            if gitrepo.is_remote_branch?(branch) # if we work with remote branch we need to sync it first
+              gitrepo.reset_hard("origin/#{branch}")
+            end
+          end
+        end
 
         return parse_files!
       ensure


### PR DESCRIPTION
Without this change, specifying a non-default branch would always be ignored and imports would always take place on the remote's default branch.

I have a private repo that has master with old community templates layout and test with new layout.  I added some debug statements to show me which branch was getting used:

```
   def parse_files!
      result_lines = []

      puts "DEBUG: #{@dir}"
      puts "DEBUG: #{@dirname}"
      puts `cd #{@dir} ; git branch`
      # Build a list of ERB files to parse

```

Before change:

```
[root@foreman-test foreman_templates-5.0.1]# foreman-rake templates:import branch=test
DEBUG: /tmp/d20171002-14908-1ac9fn3
DEBUG: /
* master
Parsing: /pxe/PXELinux_local.erb

```

After change:
```
[root@foreman-test foreman_templates-5.0.1]# foreman-rake templates:import branch=test
DEBUG: /tmp/d20171002-15505-1odl6vi
DEBUG: /
  master
* test
Parsing: /provisioning_templates/user_data/windows_2016.erb

```