### PR TITLE
Support locking imported templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ template will be automatically associated with the OS
 * dirname   => The directory within the git tree containing the templates [/]
 * filter    => Import names matching this regex (case-insensitive; snippets are not filtered)
 * associate => Associate to OS, "always", when "new" or "never"  [new]
+* lock      => Lock imported templates [false]
 
 The `branch` default will use *develop* if you're on Foreman-nightly; or the
 matching *1.X-stable* branch for your version of Foreman (if it exists); or

--- a/app/controllers/api/v2/template_controller.rb
+++ b/app/controllers/api/v2/template_controller.rb
@@ -11,6 +11,7 @@ module Api
       param :negate, :bool, :required => false, :desc => N_("Negate the prefix (for purging).")
       param :associate, Setting::TemplateSync.associate_types.keys, :required => false, :desc => N_("Associate to OS's, Locations & Organizations. Options are: always, new or never.")
       param :force, :bool, :required => false, :desc => N_("Update templates that are locked")
+      param :lock, :bool, :required => false, :desc => N_("Lock imported templates")
 
       def import
         results = ForemanTemplates::TemplateImporter.new({
@@ -22,7 +23,8 @@ module Api
           filter:    params['filter'],
           associate: params['associate'],
           negate:    params['negate'],
-          force:     params['force']
+          force:     params['force'],
+          lock:      params['lock'],
         }).import!
         render :json => { :message => results }
       end

--- a/app/models/concerns/foreman_templates/provisioning_template_import.rb
+++ b/app/models/concerns/foreman_templates/provisioning_template_import.rb
@@ -5,7 +5,7 @@ module ForemanTemplates
     module ClassMethods
       def import!(name, text, metadata, force = false, lock = false)
         # Check for snippet type
-        return import_snippet!(name, text, force) if metadata['snippet'] || metadata['kind'] == 'snippet'
+        return import_snippet!(name, text, force, lock) if metadata['snippet'] || metadata['kind'] == 'snippet'
 
         # Get template type
         kind = TemplateKind.find_by(name: metadata['kind'])

--- a/app/models/concerns/foreman_templates/provisioning_template_import.rb
+++ b/app/models/concerns/foreman_templates/provisioning_template_import.rb
@@ -26,7 +26,7 @@ module ForemanTemplates
         # Printout helpers
         c_or_u = template.new_record? ? 'Creating' : 'Updating'
         id_string = template.new_record? ? '' : "id #{template.id}"
-        if template.locked? && !template.new_record? && !force
+        if template.locked && !template.new_record? && !force
           return { :diff => nil,
                    :status => false,
                    :result => "Skipping Template #{id_string}:#{name} - template is locked" }

--- a/app/models/concerns/foreman_templates/ptable_import.rb
+++ b/app/models/concerns/foreman_templates/ptable_import.rb
@@ -20,7 +20,7 @@ module ForemanTemplates
         # Printout helpers
         c_or_u = ptable.new_record? ? 'Creating' : 'Updating'
         id_string = ptable.new_record? ? '' : "id #{ptable.id}"
-        if ptable.locked? && !ptable.new_record? && !force
+        if ptable.locked && !ptable.new_record? && !force
           return { :diff => nil,
                    :status => false,
                    :result => "Skipping Partition Table #{id_string}:#{name} - partition table is locked" }

--- a/app/models/concerns/foreman_templates/ptable_import.rb
+++ b/app/models/concerns/foreman_templates/ptable_import.rb
@@ -5,7 +5,7 @@ module ForemanTemplates
     module ClassMethods
       def import!(name, text, metadata, force = false, lock = false)
         # Check for snippet type
-        return import_snippet!(name, text, force) if metadata['snippet']
+        return import_snippet!(name, text, force, lock) if metadata['snippet']
 
         # Data
         ptable = Ptable.where(:name => name).first_or_initialize

--- a/app/models/concerns/foreman_templates/template_import.rb
+++ b/app/models/concerns/foreman_templates/template_import.rb
@@ -16,7 +16,7 @@ module ForemanTemplates
         c_or_u = snippet.new_record? ? 'Creating' : 'Updating'
         id_string = snippet.new_record? ? '' : "id #{snippet.id}"
 
-        if snippet.locked? && !snippet.new_record? && !force
+        if snippet.locked && !snippet.new_record? && !force
           return { :diff => nil,
                    :status => false,
                    :result => "Skipping snippet #{id_string}:#{name} - template is locked" }

--- a/app/models/concerns/foreman_templates/template_import.rb
+++ b/app/models/concerns/foreman_templates/template_import.rb
@@ -3,13 +3,14 @@ module ForemanTemplates
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def import_snippet!(name, text, force = false)
+      def import_snippet!(name, text, force = false, lock = false)
         # Data
         snippet = self.where(:name => name).first_or_initialize
         data = {
           :template => text,
           :snippet  => true
         }
+        data[:locked] = lock if lock
 
         # Printout helpers
         c_or_u = snippet.new_record? ? 'Creating' : 'Updating'

--- a/app/models/setting/template_sync.rb
+++ b/app/models/setting/template_sync.rb
@@ -33,6 +33,7 @@ class Setting
           self.set('template_sync_branch', N_('Default branch in Git repo'), nil, N_('Branch')),
           self.set('template_sync_metadata_export_mode', N_('Default metadata export mode, refresh re-renders metadata, keep will keep existing metadata, remove exports template withou metadata'), 'refresh', N_('Metadata export mode'), nil, { :collection => Proc.new { self.metadata_export_mode_types } }),
           self.set('template_sync_force', N_('Should importing overwrite locked templates?'), false, N_('Force import')),
+          self.set('template_sync_lock', N_('Should importing lock templates?'), false, N_('Lock templates')),
         ].compact.each { |s| self.create! s.update(:category => "Setting::TemplateSync") }
       end
 

--- a/app/services/foreman_templates/template_importer.rb
+++ b/app/services/foreman_templates/template_importer.rb
@@ -6,13 +6,14 @@ module ForemanTemplates
     attr_accessor :metadata, :name, :text
 
     def self.setting_overrides
-      super + %i(associate force)
+      super + %i(associate force lock)
     end
 
     def initialize(args = {})
       super
       @verbose = parse_bool(@verbose)
       @force = parse_bool(@force)
+      @lock = parse_bool(@lock)
     end
 
     def import!
@@ -69,17 +70,17 @@ module ForemanTemplates
         begin
           # Expects a return of { :diff, :status, :result, :errors }
           data = if metadata['model'].present?
-                   metadata['model'].constantize.import!(name, text, metadata, @force)
+                   metadata['model'].constantize.import!(name, text, metadata, @force, @lock)
                  else
                    # For backwards-compat before "model" metadata was added
                    case metadata['kind']
                    when 'ptable'
-                     Ptable.import!(name, text, metadata, @force)
+                     Ptable.import!(name, text, metadata, @force, @lock)
                    when 'job_template'
                      # TODO: update REX templates to have `model` and delete this
                      update_job_template(name, text)
                    else
-                     ProvisioningTemplate.import!(name, text, metadata, @force)
+                     ProvisioningTemplate.import!(name, text, metadata, @force, @lock)
                    end
                  end
 

--- a/lib/tasks/foreman_templates_tasks.rake
+++ b/lib/tasks/foreman_templates_tasks.rake
@@ -13,6 +13,7 @@ namespace :templates do
     # * dirname   => The directory within the git tree containing the templates [/]
     # * filter    => Import names matching this regex (case-insensitive; snippets are not filtered)
     # * associate => Associate to OS's, Locations & Organizations. Options are: always, new or never  [new]
+    # * lock      => Lock imported templates [false]
 
     User.current = User.anonymous_admin
 
@@ -24,6 +25,7 @@ namespace :templates do
       dirname:   ENV['dirname'],
       filter:    ENV['filter'],
       associate: ENV['associate'],
+      lock:      ENV['lock'],
     }).import!
 
     puts results.join("\n")

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -70,7 +70,7 @@ module ForemanTemplates
       test 'can extend without changes' do
         # Test template class
         class TestTemplate < ::Template
-          def self.import!(name, text, _metadata, force = false)
+          def self.import!(name, text, _metadata, force = false, lock = false)
             audited # core tries to call :audit_comment, breaks without this
             template = TestTemplate.new(:name => name, :template => text)
             template.save!


### PR DESCRIPTION
This would allow the behavior of this plugin to more closely mimic what's done by Foreman when it seeds in the community-templates repo.