### PR TITLE
Fixes rubocop after girl -> bot rename

### DIFF
--- a/test/unit/provisioning_template_test.rb
+++ b/test/unit/provisioning_template_test.rb
@@ -10,8 +10,8 @@ module ForemanTemplates
       @new_org = FactoryBot.create(:organization, :name => 'NewOrg')
       @new_loc = FactoryBot.create(:location, :name => 'NewLoc')
       @pt      = FactoryBot.create(:provisioning_template,
-                                    :template_kind => @tk,
-                                    :operatingsystems => [@os_old])
+                                   :template_kind => @tk,
+                                   :operatingsystems => [@os_old])
 
       # Set up the data wanted by import!
       @name     = @pt.name

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -255,10 +255,10 @@ module ForemanTemplates
 
       provision = TemplateKind.find_by :name => 'provision'
       template = FactoryBot.create(:provisioning_template,
-                                    :name => "Test Data",
-                                    :template => template_template,
-                                    :locked => true,
-                                    :template_kind => provision)
+                                   :name => "Test Data",
+                                   :template => template_template,
+                                   :locked => true,
+                                   :template_kind => provision)
       ptable = FactoryBot.create(:ptable, :name => "Test Ptable", :locked => true, :layout => ptable_layout)
       snippet = FactoryBot.create(:provisioning_template, :snippet, :name => "Test Snippet", :locked => true, :template => snippet_template)
 
@@ -282,10 +282,10 @@ module ForemanTemplates
 
       provision = TemplateKind.find_by :name => 'provision'
       template = FactoryBot.create(:provisioning_template,
-                                    :name => "Test Data",
-                                    :template => template_template,
-                                    :locked => true,
-                                    :template_kind => provision)
+                                   :name => "Test Data",
+                                   :template => template_template,
+                                   :locked => true,
+                                   :template_kind => provision)
       ptable = FactoryBot.create(:ptable, :name => "Test Ptable", :locked => true, :layout => ptable_layout)
       snippet = FactoryBot.create(:provisioning_template, :snippet, :name => "Test Snippet", :locked => true, :template => snippet_template)
 


### PR DESCRIPTION
as @xprazak2 found out elsewhere, indentation is off since "Girl".size == 4 while "Bot".size == 3 :-)