### PR TITLE
Fixes #22353 - Remove prefix from template name when exporting

### DIFF
--- a/app/services/foreman_templates/template_exporter.rb
+++ b/app/services/foreman_templates/template_exporter.rb
@@ -62,6 +62,8 @@ module ForemanTemplates
         current_dir = get_dump_dir(template)
         FileUtils.mkdir_p current_dir
 
+        set_name_without_prefix(template)
+
         filename = File.join(current_dir, get_template_filename(template))
         File.open(filename, 'w+') do |file|
           logger.debug "Writing to file #{filename}"
@@ -73,6 +75,10 @@ module ForemanTemplates
 
     def get_template_filename(template)
       Shellwords.escape(template.name.downcase.tr(' /', '_') + '.erb')
+    end
+
+    def set_name_without_prefix(template)
+      template.name = template.name.sub(@prefix, '') if template.name.start_with? @prefix
     end
 
     def get_dump_dir(template)

--- a/test/factories/sync_setting_factory.rb
+++ b/test/factories/sync_setting_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :template_sync_setting, :class => ::Setting::TemplateSync do
+    name "template_sync_empty"
+    value "random"
+    description "some text"
+    category "Setting::TemplateSync"
+    default "random"
+    full_name "Empty"
+    encrypted false
+  end
+end

--- a/test/functional/api/v2/template_controller_test.rb
+++ b/test/functional/api/v2/template_controller_test.rb
@@ -3,6 +3,10 @@ require 'test_plugin_helper'
 module Api
   module V2
     class TemplateControllerTest < ::ActionController::TestCase
+      before do
+        FactoryBot.create(:template_sync_setting, :name => 'template_sync_prefix', :value => 'community ')
+      end
+
       test "should import from git" do
         post :import, params: { 'repo' => "#{ForemanTemplates::Engine.root}/test/templates/core", 'prefix' => '' }
         assert_response :success


### PR DESCRIPTION
Adds a new setting that allows removing prefix when exporting, therefore template name does not have multiple prefixes when running export/import repeatedly. Default value is set to false.