### PR TITLE
Fixes #23958 - Improve error message for file system access denial

### DIFF
--- a/app/services/foreman_templates/action.rb
+++ b/app/services/foreman_templates/action.rb
@@ -33,7 +33,9 @@ module ForemanTemplates
     end
 
     def verify_path!(path)
-      raise "Using file-based synchronization, but couldn't find #{path}" unless Dir.exist?(path)
+      msg = _("Using file-based synchronization, but couldn't access %s to export templates. ") % path
+      msg += _("Please check the access permissions/SELinux and make sure it is writable for the web application user account, typically 'foreman'.")
+      raise msg unless Dir.exist?(path)
     end
 
     private


### PR DESCRIPTION
The export to file system works correctly as far as I can tell. The exception is raised when `path` does not exist or the user does not have proper permissions set up. For example, exports to `/root/repo` will (correctly) fail on this because foreman does not even have read permissions for `/root`, therefore it cannot find `/root/repo`. Improving the error message is the only thing we can do here.