### PR TITLE
Fixes #28650 - Display sync errors on separate lines

### DIFF
--- a/webpack/components/TemplateSyncResult/__fixtures__/templateSyncResult.fixtures.js
+++ b/webpack/components/TemplateSyncResult/__fixtures__/templateSyncResult.fixtures.js
@@ -24,7 +24,7 @@ export const exportTemplates = [
 export const noName = {
   name: null,
   templateFile: 'random_template.erb',
-  additionalErrors: 'No "name" found in metadata',
+  additionalErrors: ['No "name" found in metadata'],
   errors: null,
 };
 
@@ -55,7 +55,7 @@ export const filteredOut = {
   name: 'CoreOS default',
   templateFile: 'coreos_default.erb',
   additionalErrors: null,
-  additionalInfo: 'Skipping, this template was filtered out.',
+  additionalInfo: ['Skipping, this template was filtered out.'],
   errors: {},
   snippet: false,
   locked: false,

--- a/webpack/components/TemplateSyncResult/__tests__/__snapshots__/TemplateSyncResult.test.js.snap
+++ b/webpack/components/TemplateSyncResult/__tests__/__snapshots__/TemplateSyncResult.test.js.snap
@@ -55,7 +55,9 @@ exports[`TemplateSyncResult should render import result 1`] = `
   templates={
     Array [
       Object {
-        "additionalErrors": "No \\"name\\" found in metadata",
+        "additionalErrors": Array [
+          "No \\"name\\" found in metadata",
+        ],
         "errors": null,
         "name": null,
         "templateFile": "random_template.erb",

--- a/webpack/components/TemplateSyncResult/__tests__/__snapshots__/TemplateSyncResultReducer.test.js.snap
+++ b/webpack/components/TemplateSyncResult/__tests__/__snapshots__/TemplateSyncResultReducer.test.js.snap
@@ -33,7 +33,9 @@ Object {
   "resultAction": "import",
   "templates": Array [
     Object {
-      "additionalErrors": "No \\"name\\" found in metadata",
+      "additionalErrors": Array [
+        "No \\"name\\" found in metadata",
+      ],
       "errors": null,
       "name": null,
       "templateFile": "random_template.erb",

--- a/webpack/components/TemplateSyncResult/components/SyncedTemplate/helpers.js
+++ b/webpack/components/TemplateSyncResult/components/SyncedTemplate/helpers.js
@@ -7,8 +7,8 @@ import EmptyInfoItem from './EmptyInfoItem';
 import StringInfoItem from './StringInfoItem';
 import LinkInfoItem from './LinkInfoItem';
 
-export const itemIteratorId = (template, attr) =>
-  `${template.templateFile}-${attr}`;
+export const itemIteratorId = (template, ...rest) =>
+  `${template.templateFile}-${rest.join('-')}`;
 
 export const additionalInfo = (template, editPath) => {
   const infoAttrs = [
@@ -72,7 +72,12 @@ export const additionalInfo = (template, editPath) => {
         );
       case 'name':
         return (
-          <LinkInfoItem template={template} editPath={editPath} attr={attr} />
+          <LinkInfoItem
+            template={template}
+            editPath={editPath}
+            attr={attr}
+            key={key}
+          />
         );
       default:
         return '';
@@ -91,11 +96,16 @@ export const itemLeftContentIcon = template => {
 
 export const expandableContent = template => {
   if (Object.keys(aggregatedMessages(template)).length !== 0) {
-    const res = Object.keys(aggregatedMessages(template)).map(key => (
-      <li key={itemIteratorId(template, key)}>
-        {formatError(key, aggregatedMessages(template)[key])}
-      </li>
-    ));
+    const msgs = aggregatedMessages(template);
+
+    const res = Object.keys(msgs).map(key => {
+      const errorMsgs = aggregatedMessages(template)[key];
+      return errorMsgs.map((errValue, idx) => (
+        <li key={itemIteratorId(template, key, idx)}>
+          {formatError(key, errValue)}
+        </li>
+      ));
+    });
     return <ul>{res}</ul>;
   }
   return <span>There were no errors.</span>;
@@ -120,7 +130,7 @@ const aggregatedMessages = template => {
 
 const formatError = (key, value) => {
   const omitKeys = ['base', 'additional', 'info'];
-  if (omitKeys.reduce((memo, item) => memo || key === item, false)) {
+  if (omitKeys.filter(item => key === item)) {
     return value;
   }
 

--- a/webpack/components/TemplateSyncResult/components/__tests__/__snapshots__/SyncResultList.test.js.snap
+++ b/webpack/components/TemplateSyncResult/components/__tests__/__snapshots__/SyncResultList.test.js.snap
@@ -10,7 +10,9 @@ exports[`SyncResultList should render 1`] = `
     key="null"
     template={
       Object {
-        "additionalErrors": "No \\"name\\" found in metadata",
+        "additionalErrors": Array [
+          "No \\"name\\" found in metadata",
+        ],
         "errors": null,
         "name": null,
         "templateFile": "random_template.erb",

--- a/webpack/components/TemplateSyncResult/components/__tests__/__snapshots__/SyncedTemplate.test.js.snap
+++ b/webpack/components/TemplateSyncResult/components/__tests__/__snapshots__/SyncedTemplate.test.js.snap
@@ -11,7 +11,9 @@ exports[`SyncedTemplate should render skipped template 1`] = `
         template={
           Object {
             "additionalErrors": null,
-            "additionalInfo": "Skipping, this template was filtered out.",
+            "additionalInfo": Array [
+              "Skipping, this template was filtered out.",
+            ],
             "className": "Ptable",
             "errors": Object {},
             "humanizedClassName": "Ptable",
@@ -27,7 +29,9 @@ exports[`SyncedTemplate should render skipped template 1`] = `
         template={
           Object {
             "additionalErrors": null,
-            "additionalInfo": "Skipping, this template was filtered out.",
+            "additionalInfo": Array [
+              "Skipping, this template was filtered out.",
+            ],
             "className": "Ptable",
             "errors": Object {},
             "humanizedClassName": "Ptable",
@@ -43,7 +47,9 @@ exports[`SyncedTemplate should render skipped template 1`] = `
         template={
           Object {
             "additionalErrors": null,
-            "additionalInfo": "Skipping, this template was filtered out.",
+            "additionalInfo": Array [
+              "Skipping, this template was filtered out.",
+            ],
             "className": "Ptable",
             "errors": Object {},
             "humanizedClassName": "Ptable",
@@ -61,7 +67,9 @@ exports[`SyncedTemplate should render skipped template 1`] = `
         template={
           Object {
             "additionalErrors": null,
-            "additionalInfo": "Skipping, this template was filtered out.",
+            "additionalInfo": Array [
+              "Skipping, this template was filtered out.",
+            ],
             "className": "Ptable",
             "errors": Object {},
             "humanizedClassName": "Ptable",
@@ -78,7 +86,9 @@ exports[`SyncedTemplate should render skipped template 1`] = `
         template={
           Object {
             "additionalErrors": null,
-            "additionalInfo": "Skipping, this template was filtered out.",
+            "additionalInfo": Array [
+              "Skipping, this template was filtered out.",
+            ],
             "className": "Ptable",
             "errors": Object {},
             "humanizedClassName": "Ptable",
@@ -96,7 +106,9 @@ exports[`SyncedTemplate should render skipped template 1`] = `
         template={
           Object {
             "additionalErrors": null,
-            "additionalInfo": "Skipping, this template was filtered out.",
+            "additionalInfo": Array [
+              "Skipping, this template was filtered out.",
+            ],
             "className": "Ptable",
             "errors": Object {},
             "humanizedClassName": "Ptable",
@@ -132,7 +144,7 @@ exports[`SyncedTemplate should render skipped template 1`] = `
 >
   <ul>
     <li
-      key="coreos_default.erb-info"
+      key="coreos_default.erb-info-0"
     >
       Skipping, this template was filtered out.
     </li>
@@ -149,7 +161,9 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
         attr="name"
         template={
           Object {
-            "additionalErrors": "No \\"name\\" found in metadata",
+            "additionalErrors": Array [
+              "No \\"name\\" found in metadata",
+            ],
             "errors": null,
             "name": null,
             "templateFile": "random_template.erb",
@@ -160,7 +174,9 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
         attr="locked"
         template={
           Object {
-            "additionalErrors": "No \\"name\\" found in metadata",
+            "additionalErrors": Array [
+              "No \\"name\\" found in metadata",
+            ],
             "errors": null,
             "name": null,
             "templateFile": "random_template.erb",
@@ -171,7 +187,9 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
         attr="snippet"
         template={
           Object {
-            "additionalErrors": "No \\"name\\" found in metadata",
+            "additionalErrors": Array [
+              "No \\"name\\" found in metadata",
+            ],
             "errors": null,
             "name": null,
             "templateFile": "random_template.erb",
@@ -182,7 +200,9 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
         attr="humanizedClassName"
         template={
           Object {
-            "additionalErrors": "No \\"name\\" found in metadata",
+            "additionalErrors": Array [
+              "No \\"name\\" found in metadata",
+            ],
             "errors": null,
             "name": null,
             "templateFile": "random_template.erb",
@@ -193,7 +213,9 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
         attr="kind"
         template={
           Object {
-            "additionalErrors": "No \\"name\\" found in metadata",
+            "additionalErrors": Array [
+              "No \\"name\\" found in metadata",
+            ],
             "errors": null,
             "name": null,
             "templateFile": "random_template.erb",
@@ -206,7 +228,9 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
         mapAttr={[Function]}
         template={
           Object {
-            "additionalErrors": "No \\"name\\" found in metadata",
+            "additionalErrors": Array [
+              "No \\"name\\" found in metadata",
+            ],
             "errors": null,
             "name": null,
             "templateFile": "random_template.erb",
@@ -238,7 +262,7 @@ exports[`SyncedTemplate should render template with invalid metadata 1`] = `
 >
   <ul>
     <li
-      key="random_template.erb-additional"
+      key="random_template.erb-additional-0"
     >
       No "name" found in metadata
     </li>
@@ -409,7 +433,7 @@ exports[`SyncedTemplate should render template with validation errors 1`] = `
 >
   <ul>
     <li
-      key="epel.erb-base"
+      key="epel.erb-base-0"
     >
       This template is locked
     </li>


### PR DESCRIPTION
Before:

![base-errors-before](https://user-images.githubusercontent.com/2664090/71828401-90c6bc00-30a2-11ea-95a3-ff11a779f5cf.png)

After:

![base-errors-after](https://user-images.githubusercontent.com/2664090/71828413-96240680-30a2-11ea-8638-decac75454b0.png)


Reproducer is to have multiple errors for one attribute or `:base`