### PR TITLE
Fixes #28750 - Template controller name must be plural

### DIFF
--- a/app/controllers/api/v2/template_controller.rb
+++ b/app/controllers/api/v2/template_controller.rb
@@ -3,6 +3,10 @@ module Api
     class TemplateController < ::Api::V2::BaseController
       include ::Foreman::Controller::Parameters::TemplateParams
 
+      resource_description do
+        resource_id 'templates'
+      end
+
       def_param_group :foreman_template_sync_params do
         param :branch, String, :required => false, :desc => N_("Branch in Git repo.")
         param :repo, String, :required => false, :desc => N_("Override the default repo from settings.")


### PR DESCRIPTION
This will also require changes in hammer-cli-foreman-templates (update resource `:template` to `:templates`).