### PR TITLE
Fixes #28630 - Show filtered results of exporting

### DIFF
--- a/app/controllers/api/v2/template_controller.rb
+++ b/app/controllers/api/v2/template_controller.rb
@@ -37,7 +37,8 @@ module Api
       param_group :taxonomies, ::Api::V2::BaseController
       def export
         @result = ForemanTemplates::TemplateExporter.new(template_export_params).export!
-        render :json => { :message => @result.to_h }, :status => @result.exported ? 200 : 500
+        @result[:templates] = @result[:templates].map(&:to_h)
+        render :json => { :message => @result }, :status => @result[:error] ? 500 : 200
       end
     end
   end

--- a/app/controllers/ui_template_syncs_controller.rb
+++ b/app/controllers/ui_template_syncs_controller.rb
@@ -18,7 +18,7 @@ class UiTemplateSyncsController < ApplicationController
   end
 
   def export
-    @result = ForemanTemplates::TemplateExporter.new(ui_template_export_params).export!
+    @result = OpenStruct.new ForemanTemplates::TemplateExporter.new(ui_template_export_params).export!
 
     if @result.error
       render_errors [@result.error]

--- a/app/services/foreman_templates/export_result.rb
+++ b/app/services/foreman_templates/export_result.rb
@@ -1,42 +1,33 @@
 module ForemanTemplates
   class ExportResult
-    attr_accessor :exported, :error, :warning
-    attr_reader :templates, :git_user, :branch, :repo
+    attr_reader :template, :name, :template_file, :exported, :additional_info
 
-    def initialize(repo, branch, git_user)
-      @repo = repo
-      @branch = branch
-      @git_user = git_user
-      @error = nil
-      @warning = nil
-      @templates = []
-      @exported = false
-    end
-
-    def add_exported_templates(templates)
-      @templates.concat templates
+    def initialize(template, exported = true)
+      @template = template
+      @exported = exported
+      @name = template.name
+      @template_file = template.template_file
     end
 
     def to_h
-      { :error => @error,
-        :warning => @warning,
-        :repo => @repo,
-        :branch => @branch,
-        :git_user => @git_user,
-        :templates => dumped_files_result }
-    end
-
-    private
-
-    def dumped_files_result
-      @templates.map { |template| to_template_h template }
-    end
-
-    def to_template_h(template)
-      { :id => template.id,
-        :name => template.name,
+      {
+        :id => template.id,
+        :name => @name,
         :exported => @exported,
-        :type => template.class.name.underscore }
+        :type => template.class.name.underscore,
+        :additional_info => @additional_info
+      }
+    end
+
+    def matching_filter
+      generic_info "Skipping, 'name' filtered out based on 'filter' and 'negate' settings"
+    end
+
+    def generic_info(additional_msg)
+      @exported = false
+      @additional_info = additional_msg
+      Logging.logger('app').debug "Not exporting #{@template.name}: #{additional_msg}"
+      self
     end
   end
 end

--- a/app/views/ui_template_syncs/template_export_result.rabl
+++ b/app/views/ui_template_syncs/template_export_result.rabl
@@ -1,7 +1,7 @@
-object @template
+object @template_result
 
-attributes :name, :template_file
+attributes :name, :template_file, :additional_info
 
-node(false) do |template|
-  partial "ui_template_syncs/template_attrs", :object => template
+node(false) do |result|
+  partial "ui_template_syncs/template_attrs", :object => result.template
 end


### PR DESCRIPTION
![ScreenShot-1580483040974](https://user-images.githubusercontent.com/32508194/73549694-5ce17b00-4443-11ea-863e-e6103342844e.png)

Shows information about filtered templates in both UI and API responses.

I've refactored the code, so it looks like `import` a bit.