### PR TITLE
Fixes #31985 - show sync error in UI

### DIFF
--- a/app/controllers/ui_template_syncs_controller.rb
+++ b/app/controllers/ui_template_syncs_controller.rb
@@ -43,6 +43,6 @@ class UiTemplateSyncsController < ApplicationController
   end
 
   def render_errors(messages, severity = 'danger')
-    render :json => { :error => { :errors => { :base => messages }, :severity => severity } }, :status => :unprocessable_entity
+    render :json => { :error => { :errors => { :base => messages }, full_messages: messages, :severity => severity } }, :status => :unprocessable_entity
   end
 end


### PR DESCRIPTION
The new Formik forms don't show the validation errors properly.
This should be fixed properly, but for now we are using temporary fix
introduced in https://github.com/theforeman/foreman/commit/0ed6bc5e1d8de01909293c50e62057ae22f16d1e (https://github.com/theforeman/foreman/pull/8309)