### PR TITLE
Fixes #32291 - Fix taxonomy props in sync form

### DIFF
--- a/webpack/components/NewTemplateSync/components/NewTemplateSyncForm/NewTemplateSyncForm.js
+++ b/webpack/components/NewTemplateSync/components/NewTemplateSyncForm/NewTemplateSyncForm.js
@@ -1,158 +1,105 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import ForemanForm from 'foremanReact/components/common/forms/ForemanForm';
-import * as Yup from 'yup';
+import { useForemanLocation, useForemanOrganization } from 'foremanReact/Root/Context/ForemanContext';
+
 import SyncSettingsFields from '../SyncSettingFields';
 import SyncTypeRadios from '../SyncTypeRadios';
+import { redirectToResult, repoFormat, syncFormSchema } from './NewTemplateSyncFormHelpers';
 
-const redirectToResult = history => () =>
-  history.push({ pathname: '/template_syncs/result' });
+const NewTemplateSyncForm = ({
+  error,
+  submitForm,
+  importSettings,
+  exportSettings,
+  history,
+  validationData,
+  importUrl,
+  exportUrl,
+  initialValues,
+  userPermissions
+}) => {
+  const allowedSyncType = (currentUserPermissions, radioAttrs) =>
+    currentUserPermissions[radioAttrs.permission];
 
-const repoFormat = formatAry => value => {
-  if (value === undefined) {
-    return true;
-  }
+  const radioButtons = [
+    { label: 'Import', value: 'import', permission: 'import' },
+    { label: 'Export', value: 'export', permission: 'export' },
+  ];
 
-  const valid = formatAry
-    .map(item => value.startsWith(item))
-    .reduce((memo, item) => item || memo, false);
+  const [syncType, setSyncType] = useState(radioButtons.find(radioAttrs => allowedSyncType(userPermissions, radioAttrs)).value)
 
-  return value && valid;
-};
-
-const syncFormSchema = (syncType, settingsObj, validationData) => {
-  const schema = (settingsObj[syncType].asMutable() || []).reduce(
-    (memo, setting) => {
-      if (setting.name === 'repo') {
-        return {
-          ...memo,
-          repo: Yup.string()
-            .test(
-              'repo-format',
-              `Invalid repo format, must start with one of: ${validationData.repo.join(
-                ', '
-              )}`,
-              repoFormat(validationData.repo)
-            )
-            .required("can't be blank"),
-        };
-      }
-      return memo;
-    },
-    {}
-  );
-
-  return Yup.object().shape({
-    [syncType]: Yup.object().shape(schema),
-  });
-};
-
-class NewTemplateSyncForm extends React.Component {
-  allowedSyncType = (userPermissions, radioAttrs) =>
-    this.props.userPermissions[radioAttrs.permission];
-
-  constructor(props) {
-    super(props);
-
-    this.radioButtons = [
-      { label: 'Import', value: 'import', permission: 'import' },
-      { label: 'Export', value: 'export', permission: 'export' },
-    ];
-
-    this.state = {
-      syncType: this.radioButtons.find(radioAttrs =>
-        this.allowedSyncType(props.userPermissions, radioAttrs)
-      ).value,
-    };
-  }
-
-  updateSyncType = event => {
-    this.setState({ syncType: event.target.value });
+  const updateSyncType = event => {
+    setSyncType(event.target.value);
   };
 
-  permitRadioButtons = buttons =>
+  const permitRadioButtons = buttons =>
     buttons.filter(buttonAttrs =>
-      this.allowedSyncType(this.props.userPermissions, buttonAttrs)
+      allowedSyncType(userPermissions, buttonAttrs)
     );
 
-  initRadioButtons = syncType =>
-    this.permitRadioButtons(this.radioButtons).map(buttonAttrs => ({
+  const initRadioButtons = syncType =>
+    permitRadioButtons(radioButtons).map(buttonAttrs => ({
       get checked() {
-        return this.value === syncType;
+        return buttonAttrs.value === syncType;
       },
-      onChange: this.updateSyncType,
+      onChange: updateSyncType,
       ...buttonAttrs,
     }));
 
-  render() {
-    const {
-      error,
-      submitForm,
-      importSettings,
-      exportSettings,
-      history,
-      validationData,
-      importUrl,
-      exportUrl,
-      initialValues,
-      currentLocation,
-      currentOrganization,
-    } = this.props;
+  const addTaxParams = (key, currentTax) => params => {
+    if (currentTax && currentTax.id) {
+      return { ...params, [key]: [currentTax.id] };
+    }
+    return params;
+  };
 
-    const addTaxParams = (key, currentTax) => params => {
-      if (currentTax && currentTax.id) {
-        return { ...params, [key]: [currentTax.id] };
-      }
-      return params;
-    };
+  const addOrgParams = addTaxParams('organization_ids', useForemanOrganization());
+  const addLocParams = addTaxParams('location_ids', useForemanLocation());
 
-    const addOrgParams = addTaxParams('organization_ids', currentOrganization);
-    const addLocParams = addTaxParams('location_ids', currentLocation);
+  const resetToDefault = (fieldName, fieldValue) => resetFn =>
+    resetFn(fieldName, fieldValue);
 
-    const resetToDefault = (fieldName, fieldValue) => resetFn =>
-      resetFn(fieldName, fieldValue);
-
-    return (
-      <ForemanForm
-        onSubmit={(values, actions) => {
-          const url = this.state.syncType === 'import' ? importUrl : exportUrl;
-          return submitForm({
-            url,
-            values: compose(
-              addLocParams,
-              addOrgParams
-            )(values[this.state.syncType]),
-            message: `Templates were ${this.state.syncType}ed.`,
-            item: 'TemplateSync',
-          }).then(args => {
-            history.replace({ pathname: '/template_syncs/result' });
-          });
-        }}
-        initialValues={initialValues}
-        validationSchema={syncFormSchema(
-          this.state.syncType,
-          { import: importSettings, export: exportSettings },
-          validationData
-        )}
-        onCancel={redirectToResult(history)}
-        error={error}
-      >
-        <SyncTypeRadios
-          name="syncType"
-          controlLabel="Action type"
-          radios={this.initRadioButtons(this.state.syncType)}
-        />
-        <SyncSettingsFields
-          importSettings={importSettings}
-          exportSettings={exportSettings}
-          syncType={this.state.syncType}
-          resetField={resetToDefault}
-        />
-      </ForemanForm>
-    );
-  }
+  return (
+    <ForemanForm
+      onSubmit={(values, actions) => {
+        const url = syncType === 'import' ? importUrl : exportUrl;
+        return submitForm({
+          url,
+          values: compose(
+            addLocParams,
+            addOrgParams
+          )(values[syncType]),
+          message: `Templates were ${syncType}ed.`,
+          item: 'TemplateSync',
+        }).then(args => {
+          history.replace({ pathname: '/template_syncs/result' });
+        });
+      }}
+      initialValues={initialValues}
+      validationSchema={syncFormSchema(
+        syncType,
+        { import: importSettings, export: exportSettings },
+        validationData
+      )}
+      onCancel={redirectToResult(history)}
+      error={error}
+    >
+      <SyncTypeRadios
+        name="syncType"
+        controlLabel="Action type"
+        radios={initRadioButtons(syncType)}
+      />
+      <SyncSettingsFields
+        importSettings={importSettings}
+        exportSettings={exportSettings}
+        syncType={syncType}
+        resetField={resetToDefault}
+      />
+    </ForemanForm>
+  );
 }
 
 NewTemplateSyncForm.propTypes = {
@@ -166,8 +113,6 @@ NewTemplateSyncForm.propTypes = {
   exportUrl: PropTypes.string.isRequired,
   importUrl: PropTypes.string.isRequired,
   submitForm: PropTypes.func.isRequired,
-  currentLocation: PropTypes.object.isRequired,
-  currentOrganization: PropTypes.object.isRequired,
 };
 
 NewTemplateSyncForm.defaultProps = {

--- a/webpack/components/NewTemplateSync/components/NewTemplateSyncForm/NewTemplateSyncFormHelpers.js
+++ b/webpack/components/NewTemplateSync/components/NewTemplateSyncForm/NewTemplateSyncFormHelpers.js
@@ -1,0 +1,43 @@
+import * as Yup from 'yup';
+
+export const redirectToResult = history => () =>
+  history.push({ pathname: '/template_syncs/result' });
+
+export const repoFormat = formatAry => value => {
+  if (value === undefined) {
+    return true;
+  }
+
+  const valid = formatAry
+    .map(item => value.startsWith(item))
+    .reduce((memo, item) => item || memo, false);
+
+  return value && valid;
+};
+
+export const syncFormSchema = (syncType, settingsObj, validationData) => {
+  const schema = (settingsObj[syncType].asMutable() || []).reduce(
+    (memo, setting) => {
+      if (setting.name === 'repo') {
+        return {
+          ...memo,
+          repo: Yup.string()
+            .test(
+              'repo-format',
+              `Invalid repo format, must start with one of: ${validationData.repo.join(
+                ', '
+              )}`,
+              repoFormat(validationData.repo)
+            )
+            .required("can't be blank"),
+        };
+      }
+      return memo;
+    },
+    {}
+  );
+
+  return Yup.object().shape({
+    [syncType]: Yup.object().shape(schema),
+  });
+};

--- a/webpack/components/NewTemplateSync/components/NewTemplateSyncForm/index.js
+++ b/webpack/components/NewTemplateSync/components/NewTemplateSyncForm/index.js
@@ -2,8 +2,6 @@ import { connect } from 'react-redux';
 
 import * as FormActions from 'foremanReact/redux/actions/common/forms';
 
-import { selectLayout } from 'foremanReact/components/Layout/LayoutSelectors';
-
 import NewTemplateSyncForm from './NewTemplateSyncForm';
 
 import {
@@ -24,8 +22,6 @@ const mapStateToProps = (state, ownProps) => {
     initialValues: { ...initialFormValues },
     importSettings,
     exportSettings,
-    currentOrganization: selectLayout(state).currentOrganization,
-    currentLocation: selectLayout(state).currentLocation,
   };
 };
 


### PR DESCRIPTION
The main change is using taxonomies from context, rest is moving from class-based component to function-based one so the hooks can be used.