### PR TITLE
Fixes #36016 - Migration error 'column settings.category does not exist'

### DIFF
--- a/db/migrate/20211122154929_templates_settings_category_to_dsl.rb
+++ b/db/migrate/20211122154929_templates_settings_category_to_dsl.rb
@@ -1,5 +1,5 @@
 class TemplatesSettingsCategoryToDsl < ActiveRecord::Migration[6.0]
   def up
-    Setting.where(category: 'Setting::TemplateSync').update_all(category: 'Setting')
+    Setting.where(category: 'Setting::TemplateSync').update_all(category: 'Setting') if column_exists?(:settings, :category)
   end
 end


### PR DESCRIPTION
See:

https://github.com/theforeman/foreman/pull/9524
https://github.com/theforeman/foreman/pull/9524#issuecomment-1404661119