### PR TITLE
Fixes #37986, #37982 - Fix UI Error when importing templates

### DIFF
--- a/app/services/foreman_templates/parse_result.rb
+++ b/app/services/foreman_templates/parse_result.rb
@@ -16,7 +16,7 @@ module ForemanTemplates
         :additional_errors => @additional_errors,
         :additional_info => @additional_info,
         :exception => @exception&.message,
-        :validation_errors => errors,
+        :validation_errors => transformed_errors,
         :file => @template_file,
         :type => @template.present? ? @template.class.name.underscore : nil
       }
@@ -27,9 +27,7 @@ module ForemanTemplates
     end
 
     def errors
-      @template&.errors&.messages&.transform_values do |v|
-        v.join(', ')
-      end
+      @template&.errors
     end
 
     def corrupted_metadata
@@ -98,6 +96,14 @@ module ForemanTemplates
       else
         nil
       end
+    end
+
+    private
+
+    def transformed_errors
+      return {} unless errors
+
+      errors.to_hash.transform_values(&:last)
     end
   end
 end

--- a/test/unit/template_importer_test.rb
+++ b/test/unit/template_importer_test.rb
@@ -222,15 +222,15 @@ module ForemanTemplates
 
         template_res = find_result(results[:results], template.name)
         refute template_res.imported
-        assert_equal template_res.errors[:base], "This template is locked. Please clone it to a new template to customize."
+        assert_equal template_res.errors.full_messages.first, "This template is locked. Please clone it to a new template to customize."
 
         ptable_res = find_result(results[:results], ptable.name)
         refute ptable_res.imported
-        assert_equal ptable_res.errors[:base], "This template is locked. Please clone it to a new template to customize."
+        assert_equal ptable_res.errors.full_messages.first, "This template is locked. Please clone it to a new template to customize."
 
         snippet_res = find_result(results[:results], snippet.name)
         refute snippet_res.imported
-        assert_equal snippet_res.errors[:base], "This template is locked. Please clone it to a new template to customize."
+        assert_equal snippet_res.errors.full_messages.first, "This template is locked. Please clone it to a new template to customize."
 
         assert_equal @template_template, template.template
         assert_equal @ptable_layout, ptable.layout
@@ -317,11 +317,11 @@ module ForemanTemplates
 
         template_res = find_result(results[:results], template.name)
         refute template_res.imported
-        assert_equal template_res.errors[:base], "This template is locked. Please clone it to a new template to customize."
+        assert_equal template_res.errors.full_messages.first, "This template is locked. Please clone it to a new template to customize."
 
         ptable_res = find_result(results[:results], ptable.name)
         refute ptable_res.imported
-        assert_equal ptable_res.errors[:base], "This template is locked. Please clone it to a new template to customize."
+        assert_equal ptable_res.errors.full_messages.first, "This template is locked. Please clone it to a new template to customize."
         results
       end
     end


### PR DESCRIPTION
Importing templates through UI causes an error and the page with import results does not load.

Steps to Reproduce:

1. Have foreman instance with the templates plugin on nightly (error originates in one of the newest commits so it is not on stream yet).

2. Navigate to Hosts > Templates > Sync Templates

3. Import templates from https://github.com/theforeman/community-templates.git

Actual behavior:

The page with results does not load and two popups are displayed. One saying that templates have been imported succesfully and another saying that there has been an error.

Expected behavior:

Page with results loads normally and displays templates correctly.

It appears that UI expects the error messages to be wrapped in array as opposed to being just string, and hammer (https://github.com/theforeman/hammer-cli-foreman-templates/pull/15) expects an empty hash instead of nil when there are no errors.