### PR TITLE
Fixes #38195 - Hide http proxy setting when syncing through ssh

### DIFF
--- a/app/controllers/api/v2/template_controller.rb
+++ b/app/controllers/api/v2/template_controller.rb
@@ -13,7 +13,8 @@ module Api
         param :filter, String, :required => false, :desc => N_("Export templates with names matching this regex (case-insensitive; snippets are not filtered).")
         param :negate, :bool, :required => false, :desc => N_("Negate the prefix (for purging).")
         param :dirname, String, :required => false, :desc => N_("Directory within Git repo containing the templates.")
-        param :http_proxy_policy, ForemanTemplates.http_proxy_policy_types.keys, :required => false, :desc => N_("HTTP proxy policy for template sync. If you choose 'selected', provide the `http_proxy_id` parameter.")
+        param :http_proxy_policy, ForemanTemplates.http_proxy_policy_types.keys, :required => false, :desc => N_("HTTP proxy policy for template sync. \
+          Use only when synchronizing templates through the HTTP or the HTTPS protocol. If you choose 'selected', provide the `http_proxy_id` parameter.")
         param :http_proxy_id, :number, :required => false, :desc => N_("ID of an HTTP proxy to use for template sync. Use this parameter together with `'http_proxy_policy':'selected'`")
       end
 

--- a/webpack/components/NewTemplateSync/components/ProxySettingFields.js
+++ b/webpack/components/NewTemplateSync/components/ProxySettingFields.js
@@ -29,15 +29,19 @@ const ProxySettingsFields = ({
     <React.Fragment>
       <FormikField
         name={proxyPolicyFieldName}
-        render={({ field, form }) => (
-          <ProxySettingField
-            setting={proxyPolicySetting}
-            resetField={resetField}
-            field={field}
-            form={form}
-            fieldName={proxyPolicyFieldName}
-          />
-        )}
+        render={({ field, form }) => {
+          if (form.values[syncType]?.repo?.match(/^https?:\/\//))
+            return (
+              <ProxySettingField
+                setting={proxyPolicySetting}
+                resetField={resetField}
+                field={field}
+                form={form}
+                fieldName={proxyPolicyFieldName}
+              />
+            );
+          return <></>;
+        }}
       />
       <FormikField
         name={proxyIdFieldName}


### PR DESCRIPTION
Currently, the HTTP proxy policy setting in ui is displayed at all times. However it only goes into effect when syncing through HTTP or HTTPS. SSH sync does not use the proxy, therefore the user shoudn't be able to see the proxy policy if a protocol different from HTTP(S) is specified in the repo url.