### PR TITLE
Fixes #38195 - Hide HTTP proxy selection if url is not HTTP(S)

### DIFF
--- a/webpack/components/NewTemplateSync/components/ProxySettingFields.js
+++ b/webpack/components/NewTemplateSync/components/ProxySettingFields.js
@@ -30,7 +30,7 @@ const ProxySettingsFields = ({
       <FormikField
         name={proxyPolicyFieldName}
         render={({ field, form }) => {
-          if (form.values[syncType]?.repo?.match(/^https?:\/\//))
+          if (isHttpUrl(form.values[syncType]?.repo))
             return (
               <ProxySettingField
                 setting={proxyPolicySetting}
@@ -47,6 +47,7 @@ const ProxySettingsFields = ({
         name={proxyIdFieldName}
         render={({ field, form }) => {
           if (
+            isHttpUrl(form.values[syncType]?.repo) &&
             proxyIdSetting.value !== '' &&
             // Changing name to camel case here would unnecessarily complicate the code
             // eslint-disable-next-line camelcase
@@ -68,6 +69,8 @@ const ProxySettingsFields = ({
     </React.Fragment>
   );
 };
+
+const isHttpUrl = value => value && /^(https?:\/\/)/.test(value);
 
 ProxySettingsFields.propTypes = {
   proxyPolicySetting: PropTypes.object,


### PR DESCRIPTION
Currently, there is an issue in UI template sync that if you first enter an HTTP url, then you select custom HTTP proxy, and then you change the url to non-HTTP(S) form, the HTTP proxy field remains. The field should be only visible if the url in the in HTTP(S) form, so I added a simple check into the condition which prevents this bug from occuring.