### PR TITLE
Add breaks-robottelo workflow as per theforeman/foreman PR 10568

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,0 +1,15 @@
+name: Label a PR `breaks-robottelo` on appropriate comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  breaks-robottelo:
+    uses: theforeman/actions/.github/workflows/breaks-robottelo.yml@v0
+    permissions:
+      pull-requests: write
+    with:
+      repo: ${{ github.repository }}
+      issue: ${{ github.event.issue.number }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Before merging, `breaks-robottelo` label needs to be added to the repo manually by a maintainer